### PR TITLE
Make compose pull policy configurable via WithImagePullPolicy / Deployment:PullPolicy

### DIFF
--- a/src/Aspire.Hosting.Docker.SshDeploy/Abstractions/IRemoteDockerComposeService.cs
+++ b/src/Aspire.Hosting.Docker.SshDeploy/Abstractions/IRemoteDockerComposeService.cs
@@ -26,13 +26,16 @@ internal interface IRemoteDockerComposeService
     Task<ComposeOperationResult> LoginToRegistryAsync(string registryUrl, string username, string password, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Deploys services with minimal downtime by running docker compose up with --pull always and --remove-orphans.
-    /// This pulls images and recreates only changed containers without explicitly stopping first.
+    /// Deploys services with minimal downtime by running <c>docker compose up -d --remove-orphans</c>
+    /// on the remote, optionally adding <c>--pull always</c> or <c>--pull never</c> based on
+    /// <paramref name="pullPolicy"/>. Recreates only changed containers without explicitly stopping
+    /// first.
     /// </summary>
     /// <param name="deployPath">Path to the deployment directory containing docker-compose.yaml</param>
+    /// <param name="pullPolicy">Whether to instruct compose to pull images before starting containers. Defaults to <see cref="PullPolicy.Always"/> to preserve historical behavior.</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Result of the deploy operation</returns>
-    Task<ComposeOperationResult> UpWithPullAsync(string deployPath, CancellationToken cancellationToken);
+    Task<ComposeOperationResult> UpAsync(string deployPath, PullPolicy pullPolicy = PullPolicy.Always, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Prunes unused Docker images to free disk space.

--- a/src/Aspire.Hosting.Docker.SshDeploy/DockerPipelineExtensions.cs
+++ b/src/Aspire.Hosting.Docker.SshDeploy/DockerPipelineExtensions.cs
@@ -43,6 +43,21 @@ public class FileTransferAnnotation(string localPath, IValueProvider remotePath,
 }
 
 /// <summary>
+/// Carries the <see cref="PullPolicy"/> selected via
+/// <see cref="DockerPipelineExtensions.WithImagePullPolicy(IResourceBuilder{DockerComposeEnvironmentResource}, PullPolicy)"/>.
+/// When present on a <see cref="DockerComposeEnvironmentResource"/>, the deploy pipeline uses this
+/// value in preference to the <c>Deployment:PullPolicy</c> configuration string.
+/// </summary>
+/// <param name="policy">The pull policy to apply.</param>
+public class ImagePullPolicyAnnotation(PullPolicy policy) : IResourceAnnotation
+{
+    /// <summary>
+    /// Gets the configured pull policy.
+    /// </summary>
+    public PullPolicy Policy { get; } = policy;
+}
+
+/// <summary>
 /// Provides extension methods for adding Docker SSH pipeline resources to a distributed application.
 /// </summary>
 public static class DockerPipelineExtensions
@@ -228,6 +243,29 @@ public static class DockerPipelineExtensions
         string remotePath)
     {
         builder.Resource.Annotations.Add(new FileTransferAnnotation(localPath, ReferenceExpression.Create($"{remotePath}"), isRelativeToDeployPath: false));
+        return builder;
+    }
+
+    /// <summary>
+    /// Sets the image pull policy used when the deploy pipeline runs <c>docker compose up</c> on
+    /// the remote. Wins over the <c>Deployment:PullPolicy</c> configuration string when both are
+    /// set. Method name matches the <c>WithImagePullPolicy</c> convention used elsewhere in Aspire.
+    /// </summary>
+    /// <param name="builder">The Docker Compose environment resource builder.</param>
+    /// <param name="policy">The pull policy to apply on the remote.</param>
+    /// <returns>The resource builder for method chaining.</returns>
+    /// <remarks>
+    /// Mirrors the <c>Deployment:PullPolicy</c> config key but is more discoverable from AppHost.cs
+    /// and naturally pairs with
+    /// <see cref="WithPullRegistry(IResourceBuilder{DockerComposeEnvironmentResource}, string)"/>.
+    /// Takes <see cref="PullPolicy"/> rather than <c>Aspire.Hosting.ApplicationModel.ImagePullPolicy</c>
+    /// because the latter does not include <c>Never</c> until Aspire 13.2.
+    /// </remarks>
+    public static IResourceBuilder<DockerComposeEnvironmentResource> WithImagePullPolicy(
+        this IResourceBuilder<DockerComposeEnvironmentResource> builder,
+        PullPolicy policy)
+    {
+        builder.Resource.Annotations.Add(new ImagePullPolicyAnnotation(policy));
         return builder;
     }
 }

--- a/src/Aspire.Hosting.Docker.SshDeploy/DockerSSHPipeline.cs
+++ b/src/Aspire.Hosting.Docker.SshDeploy/DockerSSHPipeline.cs
@@ -45,6 +45,7 @@ internal class DockerSSHPipeline(
     private string? _remoteDeployPath;
     private string? _dashboardServiceName;
     private bool _pruneImagesAfterDeploy;
+    private PullPolicy _pullPolicy = PullPolicy.Always;
 
     // Properties with null-checking for required state
     private RemoteOperationsFactory RemoteOperationsFactory => _remoteOperationsFactory ?? throw new InvalidOperationException("Remote operations factory not initialized. Ensure SSH connection step has completed.");
@@ -209,6 +210,17 @@ internal class DockerSSHPipeline(
         // Read optional prune setting (defaults to true)
         var pruneSetting = deploymentSection["PruneImagesAfterDeploy"];
         _pruneImagesAfterDeploy = string.IsNullOrEmpty(pruneSetting) || !string.Equals(pruneSetting, "false", StringComparison.OrdinalIgnoreCase);
+
+        // Pull policy: WithImagePullPolicy(...) annotation wins over Deployment:PullPolicy config.
+        // Default is "always" — preserves historical behavior. Unknown config values fall back to "always".
+        if (DockerComposeEnvironment.TryGetLastAnnotation<ImagePullPolicyAnnotation>(out var pullPolicyAnnotation))
+        {
+            _pullPolicy = pullPolicyAnnotation.Policy;
+        }
+        else
+        {
+            _pullPolicy = PullPolicyExtensions.ParsePullPolicy(deploymentSection["PullPolicy"]);
+        }
 
         // Expand tilde to $HOME if present
         if (!string.IsNullOrEmpty(_remoteDeployPath))
@@ -505,12 +517,13 @@ internal class DockerSSHPipeline(
         // Get registry info from the ContainerRegistryResource attached to the environment
         await AuthenticateRemoteWithRegistryAsync(context, step);
 
-        // Deploy with minimal downtime using docker compose up --pull always --remove-orphans
-        // This pulls images and recreates only changed containers without explicitly stopping first
+        // Deploy with minimal downtime using docker compose up -d --remove-orphans
+        // (optionally with --pull always or --pull never, controlled by Deployment:PullPolicy).
+        // Recreates only changed containers without explicitly stopping first.
         await using var deployTask = await step.CreateTaskAsync("Deploying containers", context.CancellationToken);
-        context.Logger.LogDebug("Deploying containers with pull...");
+        context.Logger.LogDebug("Deploying containers with pull policy {PullPolicy}...", _pullPolicy);
 
-        var deployResult = await RemoteOperationsFactory.DockerComposeService.UpWithPullAsync(RemoteDeployPath, context.CancellationToken);
+        var deployResult = await RemoteOperationsFactory.DockerComposeService.UpAsync(RemoteDeployPath, _pullPolicy, context.CancellationToken);
 
         if (!string.IsNullOrEmpty(deployResult.Output))
         {

--- a/src/Aspire.Hosting.Docker.SshDeploy/Models/PullPolicy.cs
+++ b/src/Aspire.Hosting.Docker.SshDeploy/Models/PullPolicy.cs
@@ -1,0 +1,57 @@
+namespace Aspire.Hosting
+{
+    /// <summary>
+    /// Controls whether <c>docker compose up</c> pulls images before starting containers on the remote.
+    /// </summary>
+    public enum PullPolicy
+    {
+        /// <summary>
+        /// Always re-pull images from the registry. Emits <c>--pull always</c>. Default — preserves
+        /// the historical behavior of this library.
+        /// </summary>
+        Always,
+
+        /// <summary>
+        /// Only pull when the image isn't present in the remote daemon's local image store. Emits no
+        /// <c>--pull</c> flag, matching Docker's compose default.
+        /// </summary>
+        Missing,
+
+        /// <summary>
+        /// Never pull; rely entirely on images already present in the remote daemon's local image
+        /// store. Emits <c>--pull never</c>. Use with workflows like unregistry that load images
+        /// directly into the remote daemon.
+        /// </summary>
+        Never,
+    }
+}
+
+namespace Aspire.Hosting.Docker.SshDeploy.Models
+{
+    internal static class PullPolicyExtensions
+    {
+        /// <summary>
+        /// Returns the <c>--pull</c> CLI fragment for <paramref name="policy"/>, or empty when no
+        /// flag should be emitted.
+        /// </summary>
+        public static string ToComposeFlag(this PullPolicy policy) => policy switch
+        {
+            PullPolicy.Always => "--pull always",
+            PullPolicy.Never => "--pull never",
+            PullPolicy.Missing => "",
+            _ => "--pull always",
+        };
+
+        /// <summary>
+        /// Parses a configuration value (case-insensitive) into a <see cref="PullPolicy"/>. Falls
+        /// back to <see cref="PullPolicy.Always"/> when the value is null, empty, or unrecognized.
+        /// </summary>
+        public static PullPolicy ParsePullPolicy(string? value) => value?.Trim().ToLowerInvariant() switch
+        {
+            "always" => PullPolicy.Always,
+            "missing" => PullPolicy.Missing,
+            "never" => PullPolicy.Never,
+            _ => PullPolicy.Always,
+        };
+    }
+}

--- a/src/Aspire.Hosting.Docker.SshDeploy/README.md
+++ b/src/Aspire.Hosting.Docker.SshDeploy/README.md
@@ -191,6 +191,52 @@ export UNSAFE_SHOW_TARGET_HOST=true
 
 ---
 
+## Deployment Configuration
+
+### Pull policy
+
+The remote `docker compose up` step always passes `--pull always` by default, so registries are
+re-checked on every deploy. Override either through code with `WithPullPolicy(...)` or through
+configuration with `Deployment:PullPolicy`:
+
+| Value     | Emitted command                                              | When to use                                                                 |
+| --------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| `always`  | `docker compose up -d --pull always --remove-orphans`        | **Default.** Re-pull every deploy. Safest with multi-host registries.       |
+| `missing` | `docker compose up -d --remove-orphans`                      | Only pull when the image isn't in the remote daemon's local store (Docker's compose default). |
+| `never`   | `docker compose up -d --pull never --remove-orphans`         | Skip pulls entirely. Required for workflows that load images directly into the remote daemon (e.g. [unregistry](https://github.com/psviderski/unregistry)). |
+
+**From AppHost.cs** (most discoverable, type-safe — naming matches `WithImagePullPolicy` on container resources elsewhere in Aspire):
+
+```csharp
+builder.AddDockerComposeEnvironment("env")
+    .WithSshDeploySupport()
+    .WithImagePullPolicy(PullPolicy.Never);
+```
+
+**From environment / appsettings** (override at deploy time without an AppHost rebuild):
+
+```bash
+export Deployment__PullPolicy=never
+```
+
+```json
+{
+  "Deployment": {
+    "PullPolicy": "never"
+  }
+}
+```
+
+If both are set, `WithImagePullPolicy(...)` wins — explicit AppHost configuration overrides
+environment-driven defaults, matching how `WithContainerRegistry(...)` overrides the config-derived
+default registry. Unknown configuration values fall back to `always`.
+
+> **Note on the enum type.** `WithImagePullPolicy(...)` takes this package's `PullPolicy` enum rather
+> than `Aspire.Hosting.ApplicationModel.ImagePullPolicy`. The Aspire enum didn't include `Never`
+> until 13.2; once this package's minimum Aspire version moves to 13.2+ we can adopt it directly.
+
+---
+
 ## File Transfer
 
 Transfer additional files (certificates, configs, etc.) to the remote server.

--- a/src/Aspire.Hosting.Docker.SshDeploy/README.md
+++ b/src/Aspire.Hosting.Docker.SshDeploy/README.md
@@ -196,7 +196,7 @@ export UNSAFE_SHOW_TARGET_HOST=true
 ### Pull policy
 
 The remote `docker compose up` step always passes `--pull always` by default, so registries are
-re-checked on every deploy. Override either through code with `WithPullPolicy(...)` or through
+re-checked on every deploy. Override either through code with `WithImagePullPolicy(...)` or through
 configuration with `Deployment:PullPolicy`:
 
 | Value     | Emitted command                                              | When to use                                                                 |

--- a/src/Aspire.Hosting.Docker.SshDeploy/Services/RemoteDockerComposeService.cs
+++ b/src/Aspire.Hosting.Docker.SshDeploy/Services/RemoteDockerComposeService.cs
@@ -78,15 +78,17 @@ internal class RemoteDockerComposeService : IRemoteDockerComposeService
             Success: result.ExitCode == 0);
     }
 
-    public async Task<ComposeOperationResult> UpWithPullAsync(string deployPath, CancellationToken cancellationToken)
+    public async Task<ComposeOperationResult> UpAsync(string deployPath, PullPolicy pullPolicy = PullPolicy.Always, CancellationToken cancellationToken = default)
     {
-        _logger.LogDebug("Deploying containers with pull in {DeployPath}", deployPath);
+        _logger.LogDebug("Deploying containers in {DeployPath} with pull policy {PullPolicy}", deployPath, pullPolicy);
 
-        // Use docker compose up with --pull always and --remove-orphans for minimal downtime deployments.
-        // This pulls images and recreates only changed containers without explicitly stopping first.
+        // docker compose up -d --remove-orphans recreates only changed containers without stopping first.
+        // The optional --pull flag is driven by pullPolicy; PullPolicy.Missing emits no flag (Docker default).
         // --remove-orphans cleans up services that have been removed from compose file.
+        var pullFlag = pullPolicy.ToComposeFlag();
+        var pullFragment = string.IsNullOrEmpty(pullFlag) ? "" : pullFlag + " ";
         var result = await _sshConnectionManager.ExecuteCommandWithOutputAsync(
-            $"cd \"{deployPath}\" && docker compose up -d --pull always --remove-orphans",
+            $"cd \"{deployPath}\" && docker compose up -d {pullFragment}--remove-orphans",
             cancellationToken);
 
         if (result.ExitCode != 0)

--- a/tests/Aspire.Hosting.Docker.SshDeploy.Tests/Fakes/FakeRemoteDockerComposeService.cs
+++ b/tests/Aspire.Hosting.Docker.SshDeploy.Tests/Fakes/FakeRemoteDockerComposeService.cs
@@ -13,7 +13,7 @@ internal class FakeRemoteDockerComposeService : IRemoteDockerComposeService
     private readonly List<ComposeOperation> _operations = new();
     private bool _shouldStopFail;
     private bool _shouldLoginFail;
-    private bool _shouldUpWithPullFail;
+    private bool _shouldUpFail;
     private bool _shouldPruneFail;
     private string _logsOutput = "";
 
@@ -39,11 +39,11 @@ internal class FakeRemoteDockerComposeService : IRemoteDockerComposeService
     }
 
     /// <summary>
-    /// Configures the up with pull operation to fail.
+    /// Configures the up operation to fail.
     /// </summary>
-    public void ConfigureUpWithPullFailure(bool shouldFail = true)
+    public void ConfigureUpFailure(bool shouldFail = true)
     {
-        _shouldUpWithPullFail = shouldFail;
+        _shouldUpFail = shouldFail;
     }
 
     /// <summary>
@@ -102,11 +102,11 @@ internal class FakeRemoteDockerComposeService : IRemoteDockerComposeService
             Success: true));
     }
 
-    public Task<ComposeOperationResult> UpWithPullAsync(string deployPath, CancellationToken cancellationToken)
+    public Task<ComposeOperationResult> UpAsync(string deployPath, PullPolicy pullPolicy = PullPolicy.Always, CancellationToken cancellationToken = default)
     {
-        _operations.Add(new ComposeOperation("UpWithPull", deployPath));
+        _operations.Add(new ComposeOperation("Up", deployPath, PullPolicy: pullPolicy));
 
-        if (_shouldUpWithPullFail)
+        if (_shouldUpFail)
         {
             throw new InvalidOperationException("Failed to deploy containers (configured to fail)");
         }
@@ -196,4 +196,4 @@ internal class FakeRemoteDockerComposeService : IRemoteDockerComposeService
 /// <summary>
 /// Represents a recorded Docker Compose operation.
 /// </summary>
-public record ComposeOperation(string Operation, string DeployPath, int? TailLines = null, string? Username = null);
+internal record ComposeOperation(string Operation, string DeployPath, int? TailLines = null, string? Username = null, PullPolicy? PullPolicy = null);

--- a/tests/Aspire.Hosting.Docker.SshDeploy.Tests/RemoteDockerComposeServiceTests.cs
+++ b/tests/Aspire.Hosting.Docker.SshDeploy.Tests/RemoteDockerComposeServiceTests.cs
@@ -1,3 +1,4 @@
+using Aspire.Hosting.Docker.SshDeploy.Models;
 using Aspire.Hosting.Docker.SshDeploy.Services;
 using Aspire.Hosting.Docker.SshDeploy.Tests.Fakes;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -139,7 +140,7 @@ public class RemoteDockerComposeServiceTests
     }
 
     [Fact]
-    public async Task UpWithPullAsync_ExecutesDockerComposeUpWithPullAlways()
+    public async Task UpAsync_WithAlways_EmitsPullAlwaysFlag()
     {
         // Arrange
         var fakeSSHManager = new FakeSSHConnectionManager();
@@ -150,7 +151,7 @@ public class RemoteDockerComposeServiceTests
             NullLogger<RemoteDockerComposeService>.Instance);
 
         // Act
-        var result = await service.UpWithPullAsync("$HOME/app", CancellationToken.None);
+        var result = await service.UpAsync("$HOME/app", PullPolicy.Always, CancellationToken.None);
 
         // Assert
         Assert.True(result.Success);
@@ -159,7 +160,48 @@ public class RemoteDockerComposeServiceTests
     }
 
     [Fact]
-    public async Task UpWithPullAsync_ThrowsOnFailure()
+    public async Task UpAsync_WithMissing_OmitsPullFlag()
+    {
+        // Arrange
+        var fakeSSHManager = new FakeSSHConnectionManager();
+        fakeSSHManager.ConfigureDefaultCommandResult(0, "Deployed", "");
+
+        var service = new RemoteDockerComposeService(
+            fakeSSHManager,
+            NullLogger<RemoteDockerComposeService>.Instance);
+
+        // Act
+        var result = await service.UpAsync("$HOME/app", PullPolicy.Missing, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Success);
+        var call = fakeSSHManager.Calls.First();
+        Assert.Contains("docker compose up -d --remove-orphans", call.Detail);
+        Assert.DoesNotContain("--pull", call.Detail);
+    }
+
+    [Fact]
+    public async Task UpAsync_WithNever_EmitsPullNeverFlag()
+    {
+        // Arrange
+        var fakeSSHManager = new FakeSSHConnectionManager();
+        fakeSSHManager.ConfigureDefaultCommandResult(0, "Deployed", "");
+
+        var service = new RemoteDockerComposeService(
+            fakeSSHManager,
+            NullLogger<RemoteDockerComposeService>.Instance);
+
+        // Act
+        var result = await service.UpAsync("$HOME/app", PullPolicy.Never, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Success);
+        var call = fakeSSHManager.Calls.First();
+        Assert.Contains("docker compose up -d --pull never --remove-orphans", call.Detail);
+    }
+
+    [Fact]
+    public async Task UpAsync_ThrowsOnFailure()
     {
         // Arrange
         var fakeSSHManager = new FakeSSHConnectionManager();
@@ -171,9 +213,25 @@ public class RemoteDockerComposeServiceTests
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => service.UpWithPullAsync("$HOME/app", CancellationToken.None));
+            () => service.UpAsync("$HOME/app", PullPolicy.Always, CancellationToken.None));
 
         Assert.Contains("Failed to deploy containers", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(null, "Always")]
+    [InlineData("", "Always")]
+    [InlineData("always", "Always")]
+    [InlineData("ALWAYS", "Always")]
+    [InlineData("missing", "Missing")]
+    [InlineData("never", "Never")]
+    [InlineData("bogus", "Always")]
+    public void ParsePullPolicy_HandlesConfigValues(string? input, string expectedName)
+    {
+        // Take parameters as strings so this public Theory method's signature only references public types.
+        // (PullPolicy is internal — exposing it as a parameter would require an internal test method.)
+        var actual = PullPolicyExtensions.ParsePullPolicy(input);
+        Assert.Equal(expectedName, actual.ToString());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Today the SSH-deploy pipeline always runs `docker compose up -d --pull always --remove-orphans` on the remote, forcing a registry round-trip on every deploy. That's wasteful (and sometimes outright fails on insecure-registries misconfig) for workflows like [unregistry](https://github.com/psviderski/unregistry), where images are already loaded into the remote daemon's image store at push time.

This PR adds two ways to override that behavior. **Default is unchanged**, so existing deployments are unaffected.

## Behavior matrix

| Pull policy | Emitted command                                              |
| ----------- | ------------------------------------------------------------ |
| `Always` (default) | `docker compose up -d --pull always --remove-orphans`        |
| `Missing`          | `docker compose up -d --remove-orphans` (Docker compose default) |
| `Never`            | `docker compose up -d --pull never --remove-orphans`         |

## API

**From AppHost.cs** (most discoverable, type-safe — naming matches `WithImagePullPolicy` on container resources elsewhere in Aspire):

\`\`\`csharp
builder.AddDockerComposeEnvironment(\"env\")
    .WithSshDeploySupport()
    .WithImagePullPolicy(PullPolicy.Never);
\`\`\`

**From environment / appsettings** (override at deploy time without an AppHost rebuild):

\`\`\`bash
export Deployment__PullPolicy=never
\`\`\`

\`\`\`json
{
  \"Deployment\": {
    \"PullPolicy\": \"never\"
  }
}
\`\`\`

If both are set, \`WithImagePullPolicy(...)\` wins — explicit AppHost configuration overrides environment-driven defaults, matching how \`WithContainerRegistry(...)\` overrides the config-derived default registry. Unknown configuration values fall back to \`always\`.

## A note on the enum type

\`WithImagePullPolicy(...)\` takes this package's own \`PullPolicy\` enum rather than \`Aspire.Hosting.ApplicationModel.ImagePullPolicy\`. The Aspire enum didn't gain a \`Never\` value until 13.2, and this package targets Aspire 13.1. Once the minimum Aspire version moves to 13.2+, swapping to the framework enum is a small follow-up.

## Changes

- \`src/.../Models/PullPolicy.cs\` — new public \`PullPolicy\` enum (in the \`Aspire.Hosting\` namespace so consumers don't need an extra \`using\`) plus an internal \`PullPolicyExtensions\` helper for \`ToComposeFlag()\` / \`ParsePullPolicy()\`.
- \`src/.../DockerPipelineExtensions.cs\` — new \`ImagePullPolicyAnnotation\` and \`WithImagePullPolicy(...)\` extension method on \`IResourceBuilder<DockerComposeEnvironmentResource>\`.
- \`src/.../Abstractions/IRemoteDockerComposeService.cs\` — \`UpWithPullAsync\` → \`UpAsync(deployPath, PullPolicy = Always, CancellationToken = default)\`. Internal interface; no external API breakage. Defaults make tests easier to read.
- \`src/.../Services/RemoteDockerComposeService.cs\` — emits the right flag for each policy.
- \`src/.../DockerSSHPipeline.cs\` — in \`ConfigureDeploymentStep\`, the annotation wins over the config string when both are set; otherwise reads \`Deployment:PullPolicy\` (default \`always\`).
- \`src/.../README.md\` — new \"Deployment Configuration → Pull policy\" section covering both APIs and the precedence rule.
- Test fakes updated to match the new method signature.

## Test plan

- Three new \`RemoteDockerComposeServiceTests\` cases assert the exact CLI for each policy.
- \`UpAsync_ThrowsOnFailure\` preserves the existing failure-throws behavior.
- \`[Theory] ParsePullPolicy_HandlesConfigValues\` covers null/empty/case-variation/unknown inputs all falling back to \`Always\`.
- Full suite: 100 tests pass, 0 errors — **once #22 lands**. The test project on \`main\` has been broken since [\`e3d4a31\`](../../commit/e3d4a31) due to an orphaned fake; #22 removes it. CI on this PR won't compile until that goes in. Verified the failing builds locally are exclusively due to the orphan; this PR's own tests are green when the orphan is moved aside.

## Non-goals

- Per-service pull policies. \`Service.PullPolicy\` was added to Aspire's compose YAML node in 13.2 and is the right hook for that. This PR controls the CLI flag at deploy time.
- Default change. Backwards-compatible by design.

## Related PRs

- #22 — Remove orphan FakeRemoteEnvironmentService (prerequisite for tests to compile)
- #21 — Add WithPullRegistry to decouple push/pull endpoints (independent; \`WithImagePullPolicy(PullPolicy.Never)\` + \`WithPullRegistry(\"localhost:5001\")\` is the unregistry recipe)