### PR TITLE
Add TypeScript AppHost support

### DIFF
--- a/.agents/skills/aspire/SKILL.md
+++ b/.agents/skills/aspire/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: aspire
+description: "Use this skill when the user is working with an Aspire distributed application and needs to operate the AppHost or its resources through the Aspire CLI: start, restart, stop, or wait on the app; inspect resources, logs, traces, docs, or health; add integrations; manage secrets or config; publish, deploy, or rerun a named pipeline step; initialize Aspire in an existing app; recover missing `.modules` files in a TypeScript AppHost; discover the right frontend URL for Playwright from Aspire state; expose custom dashboard/resource commands; or understand unfamiliar Aspire AppHost APIs in C# or TypeScript. Use it even if they describe the task in terms of an AppHost, resources, dashboard, existing app bootstrap, missing generated modules, Playwright URL discovery, C# API understanding, or local distributed app workflow without explicitly naming Aspire. Do not use it for non-Aspire .NET apps, container-only repos with no AppHost, or ordinary build and test tasks."
+---
+
+# Aspire Skill
+
+Use this skill when the task is about operating an Aspire distributed application through the Aspire CLI rather than falling back to ad-hoc `dotnet`, `docker`, or shell workflows.
+
+Resources are typically defined in an AppHost such as, `AppHost.cs`, `apphost.ts`, or `AppHost/AppHost.csproj (Program.cs)`.
+
+## Use this skill for
+
+- Starting, restarting, and stopping AppHosts with `aspire start` and `aspire stop`
+- Initializing Aspire in an existing app with `aspire init` (drops skeleton files; use the `aspireify` skill to complete wiring)
+- Inspecting resources, logs, traces, and docs
+- Adding integrations with `aspire add`
+- Recovering missing TypeScript AppHost support files with `aspire restore`
+- Discovering the correct frontend URL before a Playwright handoff
+- Understanding unfamiliar Aspire AppHost APIs before editing C# or TypeScript AppHosts
+- Managing AppHost secrets and CLI config
+- Publishing and deploying Aspire apps, including single named steps with `aspire do`
+- Adding custom dashboard or resource commands with docs-backed AppHost patterns
+
+## Do not use this skill for
+
+- Non-Aspire .NET applications
+- Container-only workflows that do not involve an Aspire AppHost
+- Replacing normal build and test commands when the task is just compiling code or running unit tests
+
+## Default workflow
+
+1. Confirm that the workspace is an Aspire app and identify the AppHost.
+2. Start the app with `aspire start`. Use `--isolated` in git worktrees or whenever shared local state would be risky.
+3. Use `aspire wait <resource>` before interacting with a resource that needs to be healthy.
+4. Inspect state with `aspire describe`, then use `aspire otel logs`, `aspire logs`, `aspire otel traces`, and `aspire export` before making code changes. Display returned data using the formatting rules in [references/monitoring.md](references/monitoring.md).
+5. Before adding an integration, introducing a custom dashboard/resource command, or using an unfamiliar AppHost API, use `aspire docs search <topic>` and `aspire docs get <slug>` for workflow guidance, then use `aspire docs api search <query> --language csharp|typescript` and `aspire docs api get <id>` when you need the API reference entry itself.
+6. Re-run `aspire start` after AppHost changes. In git worktrees, re-run `aspire start --isolated` instead of switching to `aspire run`.
+
+## C# AppHosts
+
+When the AppHost is implemented in C# such as `AppHost.cs`, `apphost.cs`, or a `Program.cs`-based AppHost, use Aspire docs for workflow guidance and Aspire API docs for the reference entry before editing.
+
+- Use `aspire docs search <topic>` and `aspire docs get <slug>` when you need the documented workflow or pattern.
+- Use `aspire docs api search <query> --language csharp` and `aspire docs api get <id>` when you need the C# API reference entry for a resource builder, extension method, or member.
+- If the `dotnet-inspect` skill is available, use it to inspect local C# APIs, overloads, and builder chains when you need help understanding how the API surface is exposed in code.
+- Keep `dotnet-inspect` scoped to understanding APIs and symbols; use Aspire docs for the documented workflow and recommended pattern.
+
+## TypeScript AppHosts
+
+When the AppHost is `apphost.ts`, the `.modules/` folder at the project root contains generated TypeScript modules that expose the Aspire APIs available to the AppHost. Common files include `.modules/aspire.ts`, `base.ts`, and `transport.ts`.
+
+- Do not edit `.modules/` directly.
+- Use `aspire add <package>` to add integrations and regenerate the available APIs.
+- Inspect `.modules/aspire.ts` after `aspire add` to see the refreshed API surface.
+- The local `tsconfig.json` often includes `.modules/**/*.ts` in its compilation scope.
+
+## Key rules
+
+- Prefer `aspire start` over `dotnet run` for AppHosts. `aspire run` blocks the terminal and is a poor fit for agent workflows.
+- Re-running `aspire start` is the restart path. In git worktrees, `aspire start --isolated` is both the start and restart command. Do not combine `aspire stop` and `aspire run`.
+- Use `--apphost <path>` when the workspace has multiple AppHosts or discovery is ambiguous.
+- Use `--format Json` when another tool or script needs machine-readable output.
+- Do not guess the integration or command shape for unfamiliar AppHost changes. Use `aspire docs search` and `aspire docs get` for the documented pattern, then use `aspire docs api search` and `aspire docs api get` when you need the specific reference entry.
+- For unfamiliar C# AppHost APIs, use Aspire API docs as the primary reference and, if available, use `dotnet-inspect` only to inspect local symbols, overloads, and builder chains.
+- Never install the obsolete Aspire workload.
+- When a TypeScript AppHost uses `.modules/`, do not edit generated files directly. Use `aspire add` to regenerate APIs and inspect `.modules/aspire.ts` afterward.
+- Prefer official docs from `aspire.dev`.
+
+## Common capabilities
+
+- Use `aspire ps` when you need to discover running AppHosts before targeting one.
+- Use `aspire update` when the task is to refresh AppHost package references through the supported CLI workflow.
+- Use `aspire doctor` as an early diagnostics step when the local Aspire environment looks unhealthy.
+- Use `aspire resource`, `aspire secret`, `aspire config`, `aspire publish`, `aspire deploy`, and `aspire do` when the objective is resource operations, secrets/config management, or deployment.
+- Use `aspire restore`, `aspire cache clear`, `aspire certs trust`, and `aspire certs clean` when the task is local environment maintenance or recovery.
+
+## Playwright CLI
+
+If Playwright CLI is already configured in the environment, use Aspire first to discover the running app and its endpoints, especially when multiple frontends exist. Prefer `aspire describe --format Json` when the handoff needs to be scriptable or you need to disambiguate which frontend URL Playwright should use, then hand browser testing off to Playwright CLI.
+
+## References
+
+- For app-level lifecycle, bootstrap, and AppHost-wide commands, see [references/app-commands.md](references/app-commands.md).
+- For waiting on and operating on individual resources, see [references/resource-management.md](references/resource-management.md).
+- For app state, logs, traces, and export workflows, see [references/monitoring.md](references/monitoring.md).
+- For deployment and pipeline-step workflows, see [references/deployment.md](references/deployment.md).
+- For docs, secrets, config, diagnostics, cache, and certificates, see [references/tools-and-configuration.md](references/tools-and-configuration.md).
+- For C# AppHost API-understanding guidance, see [references/csharp-apphosts.md](references/csharp-apphosts.md).
+- For TypeScript AppHost guidance, see [references/typescript-apphosts.md](references/typescript-apphosts.md).
+- For Playwright handoff after Aspire endpoint discovery, see [references/playwright-handoff.md](references/playwright-handoff.md).
+- For investigation order and common agent workflows, see [references/agent-workflows.md](references/agent-workflows.md).

--- a/.agents/skills/aspire/references/agent-workflows.md
+++ b/.agents/skills/aspire/references/agent-workflows.md
@@ -1,0 +1,83 @@
+# Aspire Agent Workflows
+
+Use these patterns when a task needs investigation or orchestration rather than a one-off command lookup.
+
+## Scenario: I Am In A Worktree And Need A Safe Background Run
+
+Start the AppHost with `aspire start` so the CLI manages background execution. In git worktrees, use `--isolated` to avoid port conflicts and shared local state:
+
+```bash
+aspire start --isolated
+```
+
+If the next step depends on one resource, wait for it explicitly:
+
+```bash
+aspire start --isolated
+aspire wait myapi
+```
+
+Keep these points in mind:
+
+- In a git worktree, rerun `aspire start --isolated` whenever AppHost changes need to be picked up.
+- Outside worktrees, rerun `aspire start`.
+- Avoid `aspire run` in normal agent workflows because it blocks the terminal.
+
+## Scenario: Something Is Wrong, But Do Not Edit Code Yet
+
+Inspect the live app before editing code:
+
+1. `aspire describe` to check resource state.
+2. `aspire otel logs <resource>` to inspect structured logs.
+3. `aspire logs <resource>` to inspect console output.
+4. `aspire otel traces <resource>` to follow cross-service activity.
+5. `aspire export` when you need a zipped telemetry snapshot for deeper analysis or handoff.
+
+## Scenario: I Need To Add An Integration, Understand An API, Or Add A Custom Command Safely
+
+Use the docs commands first for the workflow, then use the API reference commands if you need the concrete API entry:
+
+```bash
+aspire docs search postgres
+aspire docs get <slug>
+aspire docs api search postgres --language csharp
+aspire docs api get <id>
+aspire add <package>
+```
+
+For dashboard or custom resource commands, use docs for the pattern and API docs for the specific entry:
+
+```bash
+aspire docs search "custom resource commands"
+aspire docs get custom-resource-commands
+aspire docs api search WithCommand --language csharp
+```
+
+Keep these points in mind:
+
+- Read the docs before editing the AppHost so the implementation follows a documented Aspire pattern instead of guessing the workflow.
+- Use `aspire docs api` when you need the C# or TypeScript reference entry for the exact API you are about to call.
+- If the AppHost is C# and you need to understand local overloads or builder chains, use the `dotnet-inspect` skill if it is available after checking the Aspire API reference.
+- After adding an integration, restart with `aspire start` so the updated AppHost takes effect.
+
+## Scenario: The AppHost Is TypeScript And Generated APIs Matter
+
+If the AppHost is `apphost.ts`, the `.modules/` directory contains generated TypeScript modules that expose Aspire APIs.
+
+- Do not edit `.modules/` directly.
+- Use `aspire add <package>` to regenerate the available APIs when adding integrations.
+- Use `aspire restore` if `.modules/` disappeared after a pull, clean, or branch switch.
+- Inspect `.modules/aspire.ts` after regeneration or restore to see the newly available APIs.
+
+## Scenario: I Need Secrets, Deployment, Or A Playwright Handoff
+
+Use `aspire secret` for AppHost user secrets, especially connection strings and passwords:
+
+```bash
+aspire secret set Parameters:postgres-password MySecretValue
+aspire secret list
+```
+
+Use `aspire publish` and `aspire deploy` for full deployment work, or `aspire do <step>` when the user only wants one named pipeline step such as seeding data or pushing containers.
+
+If Playwright CLI is configured in the environment, use Aspire to discover the endpoint first and let Playwright use that discovered URL afterward. When multiple frontends exist or the URL needs to be passed to another tool, prefer `aspire describe --format Json` before the Playwright handoff.

--- a/.agents/skills/aspire/references/app-commands.md
+++ b/.agents/skills/aspire/references/app-commands.md
@@ -1,0 +1,58 @@
+# App Commands
+
+Use this when the task is about app-level lifecycle, bootstrap, or AppHost-wide maintenance.
+
+## Scenario: Start The App Safely In The Background
+
+Use these commands when the user wants the AppHost running, needs a safe worktree session, or wants to pick up AppHost changes.
+
+```bash
+aspire start
+aspire start --isolated
+aspire stop
+```
+
+Keep these points in mind:
+
+- Use `aspire start` for normal background AppHost execution.
+- In git worktrees or when another local instance may already be running, use `aspire start --isolated`.
+- If the CLI shape may have changed or the skill instructions look older than the local CLI, confirm the exact command form with `aspire --help` or the relevant subcommand help before executing.
+- To restart after AppHost changes, rerun the same start command. In a worktree, rerun `aspire start --isolated`.
+- Use `aspire stop` only when the ask is explicitly to stop the app or clean up a running AppHost.
+- Avoid `aspire run` in normal agent workflows because it blocks the terminal.
+
+## Scenario: Create A New Aspire App Or Add Aspire To An Existing App
+
+Use these commands when the task is to bootstrap Aspire support.
+
+```bash
+aspire new
+aspire init
+aspire init --language typescript
+```
+
+Keep these points in mind:
+
+- Use `aspire new` when creating a brand-new Aspire app from scratch.
+- Use `aspire init` when adding Aspire to an existing application.
+- If you are unsure which arguments are supported by the installed CLI, check `aspire init --help` (or the parent help) before running it.
+- If the existing app flow needs a specific AppHost language, choose it explicitly rather than inventing unrelated scaffolding.
+
+## Scenario: Find The Right AppHost Or Refresh AppHost-Wide Support
+
+Use these commands when multiple AppHosts may be running locally, when the AppHost needs an integration, or when local AppHost support files need refresh or restore.
+
+```bash
+aspire ps
+aspire add <package>
+aspire update
+aspire restore
+```
+
+Keep these points in mind:
+
+- Use `aspire ps` first when you need to discover which AppHost is already running.
+- If command arguments may differ across CLI versions, verify the current shape with `aspire <command> --help` before execution.
+- Use `aspire add <package>` when the task is to add a supported integration or regenerate AppHost APIs.
+- Use `aspire update` when the ask is specifically to refresh AppHost package references through the supported CLI workflow.
+- Use `aspire restore` after pulls, cleans, or missing generated files when the AppHost needs its local support restored before running again.

--- a/.agents/skills/aspire/references/csharp-apphosts.md
+++ b/.agents/skills/aspire/references/csharp-apphosts.md
@@ -1,0 +1,30 @@
+# C# AppHosts
+
+Use this when the AppHost is implemented in C# and the task involves understanding APIs, extension methods, overloads, or builder chains before editing code.
+
+## Scenario: I Need Official Docs For An Unfamiliar C# AppHost API
+
+Use these commands when you need the documented Aspire pattern and the C# API reference before changing AppHost code.
+
+```bash
+aspire docs search <query>
+aspire docs get <slug>
+aspire docs api search <query> --language csharp
+aspire docs api get <id>
+```
+
+Keep these points in mind:
+
+- Use Aspire docs first when the task is about understanding an unfamiliar integration workflow or dashboard command pattern.
+- Use `aspire docs api` when the task is about finding the C# reference entry for a resource builder API, extension method, or member.
+- Search for the resource or pattern name before guessing the C# API shape.
+
+## Scenario: I Need To Read The Local C# API Surface More Closely
+
+Use this when the docs tell you what concept to use, but you still need to inspect local symbols, signatures, or overloads in C# code.
+
+Keep these points in mind:
+
+- If the `dotnet-inspect` skill is available, use it to inspect local C# APIs, extension methods, overloads, and chained builder return types.
+- Keep `dotnet-inspect` scoped to understanding APIs and symbols; do not treat it as a replacement for Aspire docs.
+- When `dotnet-inspect` is not available, fall back to reading local AppHost code together with the relevant Aspire docs pages.

--- a/.agents/skills/aspire/references/deployment.md
+++ b/.agents/skills/aspire/references/deployment.md
@@ -1,0 +1,35 @@
+# Deployment
+
+Use this when the task is about deployment artifacts, deployment execution, or named pipeline steps.
+
+## Scenario: Regenerate Deployment Artifacts And Redeploy
+
+Use these commands when the task is to build fresh deployment artifacts and run the full deployment flow.
+
+```bash
+aspire publish
+aspire deploy
+aspire deploy --clear-cache
+```
+
+Keep these points in mind:
+
+- Use `aspire publish` when artifact generation is part of the request.
+- Use `aspire deploy` when the goal is the full deployment flow, not just one step inside it.
+- Use `aspire deploy --clear-cache` when cached deployment state is stale or stuck.
+
+## Scenario: Run One Named Deployment Step Instead Of The Whole Deployment
+
+Use these commands when the deployment pipeline already exists and the user wants only one step, such as seeding data, running diagnostics, or pushing containers/images.
+
+```bash
+aspire do seed-data
+aspire do push-containers   # if the app defines this step
+aspire do diagnostics       # if the app defines this step
+```
+
+Keep these points in mind:
+
+- Use `aspire do <step>` when the request is specifically about one named pipeline step.
+- Common scenarios include seeding data, running a diagnostics step, or pushing containers/images, but the step names are app-defined.
+- Do not substitute `aspire deploy` when the request is to rerun only one step from the deployment pipeline.

--- a/.agents/skills/aspire/references/monitoring.md
+++ b/.agents/skills/aspire/references/monitoring.md
@@ -1,0 +1,82 @@
+# Monitoring
+
+Use this when the task is about inspecting app state, logs, traces, endpoints, or sharable diagnostics.
+
+## Scenario: I Need To Know What Is Running And Where The Endpoints Are
+
+Use these commands when the first job is to inspect current resource state, find URLs, or hand machine-readable app state to another tool.
+
+```bash
+aspire describe
+aspire resources
+aspire describe --apphost <path>
+aspire describe --apphost <path> --format Json
+```
+
+Keep these points in mind:
+
+- Use `aspire describe` first when you need the current state of the running app before deciding what to do next.
+- Use `--apphost <path>` when the workspace has multiple AppHosts or discovery is ambiguous.
+- Prefer `--format Json` when another tool or script needs to consume the result, such as a Playwright handoff or endpoint extraction.
+
+## Scenario: Something Is Wrong, But Investigate Before Editing Code
+
+Use these commands when the task is to diagnose behavior in the live app before making code changes.
+
+```bash
+aspire otel logs [resource] --format Json
+aspire otel traces [resource] --format Json
+aspire otel spans [resource] --format Json
+aspire otel logs --trace-id <id> --format Json
+aspire logs [resource]
+```
+
+Keep these points in mind:
+
+- Prefer structured telemetry before raw console logs when possible.
+- Use `aspire logs` as a secondary console-output view after checking structured telemetry.
+- Use the trace-filtered log command when you already have a trace id and want the related log slice.
+- Prefer `--format Json` when another tool or script needs to consume the result, such as a Playwright handoff or endpoint extraction.
+- `[resource]` is optional. Include it to filter results to a single resource; omit it to see all resources.
+
+## Scenario: I Need A Sharable Diagnostics Bundle
+
+Use this command when you need a portable handoff artifact for deeper analysis or for another person to inspect offline.
+
+```bash
+aspire export [resource]
+```
+
+Keep this point in mind:
+
+- Use `aspire export` when you need a sharable bundle of telemetry and resource state.
+
+## Dashboard Links
+
+Commands like `aspire describe`, `aspire otel logs`, `aspire otel traces`, and `aspire otel spans` may include dashboard URLs in their JSON output. Only use URLs that are explicitly returned by these commands — do not construct dashboard URLs yourself.
+
+When a dashboard link is returned alongside a resource or telemetry entry, make the resource name, trace ID, or span ID a clickable markdown link using the returned URL.
+
+## Displaying Resources
+
+When showing resource state to the user, display the state text with a circle emoji prefix:
+
+- 🟢 Running, healthy
+- 🟡 Starting, waiting
+- 🔴 Failed, error, unhealthy
+- ⚪ Stopped, exited
+
+Link resource names to their dashboard page when the dashboard URL is known.
+
+## Displaying Telemetry
+
+When showing structured logs, prefix each entry with an emoji matching the log level:
+
+- 🔴 Error / Critical
+- 🟡 Warning
+- 🔵 Information
+- ⚪ Debug / Trace
+
+Link resource names to their dashboard resource page. When trace IDs are present, display the first 7 characters and link that value to the full trace detail page.
+
+When showing traces or spans, use 🟢 for success/unset status and 🔴 for error status. Display only the first 7 characters of trace and span IDs, and link those values to their dashboard detail pages.

--- a/.agents/skills/aspire/references/playwright-handoff.md
+++ b/.agents/skills/aspire/references/playwright-handoff.md
@@ -1,0 +1,21 @@
+# Playwright Handoff
+
+Use this when Playwright CLI is already configured and the next step is browser testing against a running Aspire app.
+
+## Scenario: I Need The Right Frontend URL Before Browser Testing
+
+Use these commands when the task is to discover the live frontend endpoint from Aspire state and then hand that URL to Playwright.
+
+```bash
+aspire describe --format Json
+aspire describe --apphost <path> --format Json
+playwright-cli --help
+```
+
+Keep these points in mind:
+
+- Aspire discovers the endpoint first; Playwright uses the discovered endpoint after the handoff.
+- Prefer `aspire describe --format Json` when the URL needs to be consumed by a script or passed to another tool.
+- Use `--apphost <path>` when multiple AppHosts exist and the user is asking about one specific app.
+- Do not guess frontend endpoints without first consulting Aspire state.
+- If multiple frontends exist, use Aspire state to disambiguate which URL Playwright should use.

--- a/.agents/skills/aspire/references/resource-management.md
+++ b/.agents/skills/aspire/references/resource-management.md
@@ -1,0 +1,35 @@
+# Resource Management
+
+Use this when the task is scoped to one resource or depends on a specific resource becoming healthy.
+
+## Scenario: Wait For One Resource Before Touching It
+
+Use these commands when the next step depends on one resource being ready, such as before calling an API, opening a frontend, or querying a database.
+
+```bash
+aspire wait <resource>
+aspire wait <resource> --status up --timeout 60
+```
+
+Keep these points in mind:
+
+- Use `aspire wait` before a dependent action when readiness is the real blocker.
+- Add `--status` and `--timeout` when the ask calls for an explicit readiness condition rather than a generic wait.
+- Treat readiness as a resource-scoped concern; a missing ready signal is not automatically a reason to restart the whole AppHost.
+
+## Scenario: Fix Or Operate On One Resource Without Bouncing The Whole App
+
+Use these commands when the user calls out one resource by name, such as Redis, Postgres, cache, or a single custom resource command.
+
+```bash
+aspire resource <resource> start
+aspire resource <resource> stop
+aspire resource <resource> restart
+aspire resource <resource> <command>
+```
+
+Keep these points in mind:
+
+- Prefer resource-scoped commands when the task does not require an AppHost-wide restart.
+- If the user says one resource is wedged, use `aspire resource <resource> restart` before escalating to `aspire start`.
+- Use `aspire resource <resource> <command>` when the AppHost exposes a resource-specific dashboard or operational command.

--- a/.agents/skills/aspire/references/tools-and-configuration.md
+++ b/.agents/skills/aspire/references/tools-and-configuration.md
@@ -1,0 +1,72 @@
+# Tools And Configuration
+
+Use this when the task is about docs lookup, API reference lookup, secrets, CLI configuration, diagnostics, cache cleanup, or local certificates.
+
+## Scenario: I Need Docs Or API Reference Before I Change The AppHost
+
+Use these commands when the task is to confirm the right Aspire workflow before editing code or retrieve a specific API reference entry.
+
+```bash
+aspire docs search <query>
+aspire docs get <slug>
+aspire docs api search <query> --language csharp|typescript
+aspire docs api list <scope>
+aspire docs api get <id>
+```
+
+Keep these points in mind:
+
+- Use docs commands before changing integrations when you need to confirm the supported path or recommended workflow.
+- Use docs commands before implementing custom resource commands or unfamiliar AppHost patterns such as `WithCommand`.
+- Use `aspire docs api` when the user needs the C# or TypeScript reference entry for a specific Aspire API.
+- Use `aspire docs api list <scope>` to browse children under a language, package, module, type, or symbol.
+
+## Scenario: I Need To Inspect Or Change AppHost Secrets
+
+Use these commands when the task is about AppHost user secrets such as connection strings, passwords, or API keys.
+
+```bash
+aspire secret set <key> <value>
+aspire secret get <key>
+aspire secret list
+aspire secret path
+aspire secret delete <key>
+```
+
+Keep these points in mind:
+
+- Use `aspire secret` for AppHost user secrets instead of inventing another storage path.
+- Use `aspire secret path` when the task is to locate the backing store without opening it manually.
+
+## Scenario: I Need To Explain Where Aspire CLI Settings Came From
+
+Use these commands when the question is about effective Aspire CLI configuration or conflicting local versus global settings.
+
+```bash
+aspire config set <key> <value>
+aspire config get <key>
+aspire config list
+aspire config delete <key>
+aspire config info
+```
+
+Keep these points in mind:
+
+- Use `aspire config info` when the user wants to know where settings come from, which settings files are in play, or why the CLI is behaving a certain way locally.
+
+## Scenario: My Local Aspire Setup Feels Broken
+
+Use these commands when the local Aspire environment looks unhealthy and needs recovery steps rather than AppHost code changes.
+
+```bash
+aspire doctor
+aspire cache clear
+aspire certs trust
+aspire certs clean
+```
+
+Keep these points in mind:
+
+- Use `aspire doctor` early when the symptoms suggest local environment drift rather than an app bug.
+- Use `aspire cache clear` when cached state is stale or interfering with normal operation.
+- Use `aspire certs trust` and `aspire certs clean` when local certificate state is part of the problem.

--- a/.agents/skills/aspire/references/typescript-apphosts.md
+++ b/.agents/skills/aspire/references/typescript-apphosts.md
@@ -1,0 +1,35 @@
+# TypeScript AppHosts
+
+Use this when the AppHost is `apphost.ts` and the task involves generated APIs or TypeScript-specific Aspire workflows.
+
+## Scenario: I Added An Integration And Need New APIs To Show Up In `apphost.ts`
+
+Use this when the task touches `.modules/` or newly added integrations.
+
+```bash
+aspire add <package>
+```
+
+Keep these points in mind:
+
+- The `.modules/` folder contains generated TypeScript modules that expose Aspire APIs to the AppHost.
+- Common generated files include `.modules/aspire.ts`, `base.ts`, and `transport.ts`.
+- Do not edit `.modules/` directly.
+- Use `aspire add <package>` to regenerate the available APIs after adding an integration.
+- Inspect `.modules/aspire.ts` after `aspire add` to see the refreshed API surface available to `apphost.ts`.
+- The local `tsconfig.json` often includes `.modules/**/*.ts` in its compilation scope.
+
+## Scenario: `.modules/` Disappeared After A Pull, Clean, Or Branch Switch
+
+Use this when generated support files are missing or stale and the TypeScript AppHost needs to be restored.
+
+```bash
+aspire restore
+```
+
+Keep these points in mind:
+
+- Try `aspire restore` first when generated `.modules/*` files are missing.
+- `aspire restore` restores and regenerates the TypeScript AppHost support files under `.modules/`.
+- Do not manually recreate or edit generated module files.
+- After recovery, inspect `.modules/aspire.ts` to confirm the available API surface.

--- a/.agents/skills/aspireify/SKILL.md
+++ b/.agents/skills/aspireify/SKILL.md
@@ -1,0 +1,710 @@
+---
+name: aspireify
+description: "One-time skill for completing Aspire initialization in an existing app after `aspire init` has dropped the skeleton AppHost. Use this skill when an `aspire.config.json` exists but the AppHost has not yet been wired up."
+---
+
+# Aspireify
+
+This is a **one-time setup skill**. It completes the Aspire initialization that `aspire init` started. After this skill finishes successfully, the evergreen `aspire` skill handles ongoing AppHost work. Do not delete this skill unless the user explicitly asks.
+
+Keep this as **one skill with context-specific references**. Load the reference files that match the repo you discover instead of trying to keep every edge case in the main document.
+
+## Guiding principles
+
+### Minimize changes to the user's code
+
+The default stance is **adapt the AppHost to fit the app, not the other way around**. The user's services already work — the goal is to model them in Aspire without breaking anything.
+
+- Prefer `WithEnvironment()` to match existing env var names over asking users to rename vars in their code
+- Prefer Aspire-managed ports (`WithHttpsEndpoint(env: "PORT")`, `WithHttpEndpoint(env: "PORT")`, or no explicit port when supported) over fixed ports
+- Only preserve a specific port when the user confirms it is actually significant (for example: external callbacks, OAuth redirect URIs, browser extensions, webhooks, or a repo-documented hard requirement)
+- Map existing `docker-compose.yml` config 1:1 before optimizing
+- Don't restructure project directories, rename files, or change build scripts
+
+### Surface tradeoffs, don't decide silently
+
+Sometimes a small code change unlocks significantly better Aspire integration. When this happens, **present the tradeoff to the user and let them decide**. Examples:
+
+- **Connection strings**: A service reads `DATABASE_URL` but Aspire injects `ConnectionStrings__mydb`. You can use `WithEnvironment("DATABASE_URL", db.Resource.ConnectionStringExpression)` (zero code change) or suggest the service reads from config so `WithReference(db)` just works (enables service discovery, health checks, auto-retry).
+  → Ask: *"Your API reads DATABASE_URL. I can map that with WithEnvironment (no code change) or you could switch to reading ConnectionStrings:mydb which unlocks WithReference and automatic service discovery. Which do you prefer?"*
+
+- **Port binding**: A service hardcodes `PORT=3000`. You can preserve that with `WithHttpsEndpoint(port: 3000)` (zero code change) or switch the service to read `PORT` from env so Aspire can manage ports dynamically and avoid conflicts.
+  → Ask: *"Your frontend is currently fixed to port 3000. Unless that exact port is important for something external, I recommend switching it to read PORT from env so Aspire can manage the port and avoid conflicts. If you need 3000 to stay stable, I can preserve it. Which do you want?"*
+
+- **OTel setup**: Service has its own tracing config pointing to Jaeger. You can leave it (Aspire won't show its traces) or suggest switching the exporter to read `OTEL_EXPORTER_OTLP_ENDPOINT` (which Aspire injects).
+  → Ask: *"Your API exports traces to Jaeger directly. I can leave that, or switch it to use the OTEL_EXPORTER_OTLP_ENDPOINT env var so traces show up in the Aspire dashboard. The Jaeger endpoint would still work in non-Aspire environments. Want me to update it?"*
+
+**Format for presenting tradeoffs:**
+1. Explain what the current code does
+2. Show the zero-change option and what it gives you
+3. Show the small-change option and the extra benefits
+4. Ask which they prefer
+5. If they decline the change, implement the zero-change option without complaint
+
+### When in doubt, ask
+
+If you're unsure whether something is a service, whether two services depend on each other, whether a port is truly significant, or whether a Docker Compose service should be modeled — ask. Don't guess at architectural intent.
+
+### Always use latest Aspire APIs — verify before you write
+
+**Do not assume APIs exist.** Before writing any AppHost code, look up the correct API using `aspire docs search` and `aspire docs get`. Follow the tiered preference: Tier 1 (first-party `Aspire.Hosting.*`) → Tier 2 (community `CommunityToolkit.Aspire.Hosting.*`) → Tier 3 (raw `AddExecutable`/`AddDockerfile`/`AddContainer`). See the "Looking up APIs and integrations" section below for full discovery workflow, tier details, and auto-managed values.
+
+**Don't invent APIs** — if docs search and integration list don't return it, it doesn't exist. Fall back to Tier 3. **API shapes differ between C# and TypeScript** — always check the correct language docs.
+
+### Choosing the right JavaScript resource type
+
+For JavaScript/TypeScript apps, pick the right resource type (`AddViteApp`, `AddNodeApp`, or `AddJavaScriptApp`) and configure dev scripts and port binding. See [references/javascript-apps.md](references/javascript-apps.md) for the selection table, dev script patterns, framework-specific port binding, and browser suppression.
+
+### Never call it ".NET Aspire"
+
+Always refer to the product as just **Aspire**, never ".NET Aspire". This applies to all comments in generated AppHost code, messages to the user, and any documentation you produce.
+
+### Dashboard URL must include auth token
+
+When printing or displaying the Aspire dashboard URL to the user, always include the full login token query parameter. The dashboard requires authentication — a bare URL like `http://localhost:18888` won't work. Use the full URL as printed by `aspire start` (e.g., `http://localhost:18888/login?t=<token>`).
+
+### Redis and auto-TLS
+
+Aspire's infrastructure automatically provisions TLS certificates for container resources that register `WithHttpsCertificateConfiguration` callbacks. `AddRedis()` registers one by default, which means **Redis will get TLS automatically** when the Aspire dev cert infrastructure is active. This is usually fine, but some apps expect plain (non-TLS) Redis.
+
+If Redis health checks fail with `SslStream` / `RedisConnectionException` errors about SSL/TLS handshake failures, the cause is this auto-TLS behavior. **Do not fall back to `AddContainer()`.** Instead, disable the certificate on the Redis resource:
+
+```csharp
+var redis = builder.AddRedis("redis")
+    .WithoutHttpsCertificate();  // plain Redis, no TLS
+```
+
+`WithoutHttpsCertificate()` suppresses the auto-TLS cert injection so Redis stays on plain TCP. Use this when the consuming services don't support TLS Redis connections.
+
+### Prefer HTTPS over HTTP
+
+Always set up HTTPS endpoints by default. Use `WithHttpsEndpoint()` instead of `WithHttpEndpoint()` unless HTTPS doesn't work for a specific integration. For JavaScript and Python apps, call `WithHttpsDeveloperCertificate()` to configure the dev cert. If HTTPS causes issues for a specific resource, fall back to HTTP and leave a comment explaining why. See the "Endpoints and ports" section in the AppHost wiring reference below for detailed patterns and examples.
+
+### Never hardcode URLs — use endpoint references
+
+When a service needs another service's URL as an environment variable, **always** pass an endpoint reference — never a hardcoded string. Hardcoded URLs break whenever Aspire assigns different ports. See the "Cross-service environment variable wiring" section in the AppHost wiring reference below for examples.
+
+Similarly, **never use `withUrlForEndpoint` / `WithUrlForEndpoint` to set `dev.localhost` URLs**. That API is ONLY for setting display labels in the dashboard (e.g., `url.DisplayText = "Web UI"`). `dev.localhost` configuration belongs in `aspire.config.json` profiles — see Step 9.
+
+### Optimize for local dev, not deployment
+
+This skill is about getting a great **local development experience**. Don't worry about production deployment manifests, cloud provisioning, or publish configuration — that's a separate concern for later.
+
+This means:
+
+- Prefer `ContainerLifetime.Persistent` for databases and caches so data survives AppHost restarts
+- Use `WithDataVolume()` to persist data across container recreations
+- Cookie and session isolation with `*.dev.localhost` subdomains is encouraged
+- Don't add production health check probes, scaling config, or cloud resource definitions
+- If services reference external third-party APIs/services (e.g., a hardcoded Stripe URL, an external database host, a SaaS webhook endpoint), consider modeling those as parameters or connection strings in the AppHost so they're visible and configurable from one place:
+
+```csharp
+// Instead of the service hardcoding "https://api.stripe.com"
+var stripeUrl = builder.AddParameter("stripe-url", secret: false);
+var api = builder.AddCSharpApp("api", "../src/Api")
+    .WithEnvironment("STRIPE_API_URL", stripeUrl);
+```
+
+This makes the external dependency visible in the dashboard and lets developers easily swap endpoints (e.g., to a Stripe test endpoint) without digging through service code. Present this as an option to the user — don't silently refactor their external service calls.
+
+### Migrate `.env` files into AppHost parameters
+
+Many projects use `.env` files for configuration. These should be migrated into the AppHost so that all config is centralized and visible in the dashboard. Scan for `.env`, `.env.local`, `.env.development`, etc. and propose migrating their contents:
+
+- **Secrets** (API keys, tokens, passwords, connection strings): use `AddParameter(name, secret: true)`. Aspire stores these securely via user secrets and prompts the developer to set them.
+- **Non-secret config** (feature flags, URLs, mode settings): use `AddParameter(name, secret: false)` with a default value, or `WithEnvironment()` directly.
+- **Values that map to Aspire resources** (e.g., `DATABASE_URL=postgres://...`, `REDIS_URL=redis://...`): replace with actual Aspire resources (`AddPostgres`, `AddRedis`) and `WithReference()` — the connection string is then managed by Aspire.
+
+```csharp
+// Before: .env file with DATABASE_URL=postgres://user:pass@localhost:5432/mydb
+//         STRIPE_KEY=sk_test_abc123
+//         DEBUG=true
+
+// After: modeled in AppHost
+var db = builder.AddPostgres("pg").AddDatabase("mydb");
+var stripeKey = builder.AddParameter("stripe-key", secret: true);
+
+var api = builder.AddCSharpApp("api", "../src/Api")
+    .WithReference(db)                              // replaces DATABASE_URL
+    .WithEnvironment("STRIPE_KEY", stripeKey)       // secret, stored securely
+    .WithEnvironment("DEBUG", "true");              // plain config
+```
+
+**Important: Never delete `.env` files automatically.** After migrating all values into the AppHost, explicitly ask the user:
+> "I've migrated all the values from your `.env` file into the AppHost. The `.env` file is no longer needed for running via Aspire, but it still works for non-Aspire workflows. Would you like me to remove it, or keep it around?"
+
+Some teams still need `.env` files for CI, Docker Compose, or developers who haven't switched to Aspire yet. Respect that.
+
+Present this as a recommendation. Walk through the `.env` contents with the user and classify each variable together. Some values may be intentionally local-only and the user may prefer to keep them — that's fine.
+
+### Migrate .NET User Secrets into AppHost parameters
+
+.NET projects often use `dotnet user-secrets` for local development configuration. Look for:
+
+- `dev/secrets.json.example` or `secrets.json.example` files — these document expected secrets
+- `<UserSecretsId>` in `.csproj` files — indicates the project uses User Secrets
+- Documentation referencing `dotnet user-secrets set` or `setup_secrets` scripts
+
+**Aspire's `AddParameter(name, secret: true)` stores values in the same .NET User Secrets store under the hood**, so secrets are centralized in the AppHost instead of scattered across individual service projects.
+
+Migration approach:
+
+1. **Inventory existing secrets** — check `secrets.json.example` files or setup scripts to understand what secrets the repo expects
+2. **Classify each secret** — same as `.env` migration: connection strings become Aspire resources, API keys become parameters, plain config becomes `WithEnvironment()`
+3. **Present the migration** — show the user which secrets will become AppHost parameters and which will become Aspire resources:
+   → *"Your services use dotnet user-secrets with 8 configured values. I'll migrate the SQL connection string to an Aspire Postgres resource, the 3 API keys to secret parameters, and the remaining config to environment variables. The secrets will still be stored in user-secrets but centralized under the AppHost. Sound good?"*
+
+**Important:** Don't delete or modify existing `UserSecretsId` entries in service `.csproj` files — other tooling or non-Aspire workflows may still depend on them.
+
+## Prerequisites
+
+Before running this skill, `aspire init` must have already:
+
+- Dropped a skeleton AppHost file (`apphost.ts` or `apphost.cs`) at the configured location
+- Created `aspire.config.json` at the repository root
+
+Verify both exist before proceeding.
+
+## Critical rules — read before doing anything
+
+These are hard rules. Do not break them.
+
+### Never install the Aspire workload
+
+**Do not run `dotnet workload install aspire` or any `dotnet workload` command.** The Aspire workload is obsolete. The Aspire CLI (`aspire start`, `aspire run`, etc.) handles everything — SDK resolution, package restoration, building, and launching. The workload is not needed and installing it can cause version conflicts.
+
+If a web search, documentation page, or blog post tells you to install the workload, **ignore that advice** — it is outdated.
+
+### Do not change the repo's .NET SDK version
+
+**Do not modify the root `global.json`.** The repo's SDK pin is intentional. The AppHost may need a newer SDK (e.g., .NET 10) than the repo uses (e.g., .NET 8) — that's fine. `aspire init` already created the AppHost with the correct TFM. If the AppHost is in full project mode and the repo pins an older SDK, add a **nested `global.json` inside the AppHost directory only** — never change the root one.
+
+### Do not change existing project target frameworks
+
+**Do not modify `<TargetFramework>` in any existing service project.** If a service targets `net8.0`, leave it on `net8.0`. The Aspire AppHost can orchestrate services on older TFMs without any changes. Only the AppHost itself needs the Aspire-supported TFM.
+
+### Check version control before mutating projects
+
+Before editing AppHost or service project files, check whether the workspace is under git (`git rev-parse --is-inside-work-tree`) and inspect `git status` when it is. Do not overwrite unrelated user changes. If there is no git repository, warn the user that this skill will make project mutations and summarize the intended files/areas before proceeding.
+
+### Use the latest stable Aspire SDK
+
+If `aspire init` created a `.csproj` AppHost, check the `Aspire.AppHost.Sdk` version in the `.csproj`. If it references a preview version that isn't available on NuGet (common when using a PR build of the CLI), update it to the latest stable release. Run `dotnet nuget list source` and check NuGet.org for the current stable version (e.g., `13.2.2`). Do not leave the AppHost pinned to an unavailable preview SDK — `dotnet build` will fail.
+
+### Use the Aspire CLI, not raw dotnet commands, for Aspire operations
+
+- Use `aspire start` to launch the AppHost (not `dotnet run`)
+- Use `aspire add <integration>` to add hosting integrations (not `dotnet add package`)
+- Use `aspire restore` to restore TypeScript AppHost dependencies
+- Use `aspire docs search` to look up APIs
+
+Standard `dotnet` commands (`dotnet build`, `dotnet add reference`, `dotnet sln add`) are fine for normal .NET operations like building projects, adding project references, and managing solution membership.
+
+## Determine your context
+
+Read `aspire.config.json` at the repository root **if it exists**. Key fields:
+
+- **`appHost.language`**: `"typescript/nodejs"` or `"csharp"` — determines which syntax and tooling to use
+- **`appHost.path`**: path to the AppHost file or project directory — this is where you'll edit code
+
+For C# AppHosts, there are two sub-modes:
+
+- **Single-file mode**: `appHost.path` points directly to an `apphost.cs` file using the `#:sdk` directive. No `.csproj` needed. Configuration lives in `aspire.config.json`.
+- **Full project mode**: A directory containing a `.csproj`, `Program.cs`, and `Properties/launchSettings.json`. This was created by `aspire init` using the `aspire-apphost` template because a `.sln`/`.slnx` was found. **The template-generated AppHost is correct and complete** — it has proper SDK references, launch profiles with randomized ports, and a skeleton `Program.cs`. Do not recreate or hand-edit the `.csproj` or `launchSettings.json`. Configuration lives in `Properties/launchSettings.json` inside the AppHost project directory (standard .NET launch settings), **not** in `aspire.config.json`.
+
+### Configuration files — which is which
+
+**Do not confuse these files. Do not create or modify config files for the user's service projects — only for the AppHost.**
+
+| File | Where it lives | What it's for | Who uses it |
+|------|---------------|---------------|-------------|
+| `aspire.config.json` | Repo root | AppHost path, language, profiles (ports, env vars) | Single-file and polyglot AppHosts only |
+| `Properties/launchSettings.json` | Inside the AppHost project dir | Launch profiles (ports, env vars) | Full project mode `.csproj` AppHosts (standard .NET) |
+| `appsettings.json` | Inside service projects | Service-specific configuration | The services themselves — **do not create or modify these** |
+| `launchSettings.json` in service projects | Inside service project dirs | Service launch config | The services themselves — **do not create or modify these** |
+
+**Key rule:** When the AppHost is a `.csproj` project, it's a standard .NET project. It uses `Properties/launchSettings.json` for launch profiles, just like any other .NET project. `aspire init` creates this file with the correct ports. Do not create a duplicate `aspire.config.json` for project-mode AppHosts.
+
+Check which mode you're in by looking at what exists at the `appHost.path` location. If there's no `aspire.config.json`, look for a `.csproj` AppHost directory with `Properties/launchSettings.json` instead.
+
+If you're in **full project mode**, also load [references/full-solution-apphosts.md](references/full-solution-apphosts.md). It covers:
+
+- mixed-SDK solution boundaries
+- when to add or avoid solution membership
+- ServiceDefaults in solution-backed repos
+- legacy `Program.cs` / `Startup.cs` / `IHostBuilder` migration decisions
+- validation specific to `.csproj` AppHosts
+
+## Workflow
+
+Follow these steps in order. If any step fails, diagnose and fix before continuing. **The goal is a working `aspire start` — keep going until every resource starts cleanly and the dashboard is accessible. Do not stop at partial success.**
+
+### Step 1: Scan the repository
+
+Analyze the repository to discover all projects and services that could be modeled in the AppHost.
+
+**What to look for:**
+
+- **.NET projects**: `*.csproj` files. For each, run:
+  - `dotnet msbuild <project> -getProperty:OutputType` — `Exe`/`WinExe` = runnable service, `Library` = skip
+  - `dotnet msbuild <project> -getProperty:TargetFramework` — must be `net8.0` or newer
+  - `dotnet msbuild <project> -getProperty:IsAspireHost` — skip if `true`
+- **Solution files**: `*.sln` or `*.slnx` — if found, the C# AppHost **must** use full project mode (with `.csproj`) so it can be opened in Visual Studio alongside the rest of the solution. This is a hard requirement.
+- **Node.js/TypeScript apps**: directories with `package.json` containing a `start`, `dev`, or `main`/`module` entry. For each, also check:
+  - Does it have a `vite.config.*` file? → use `AddViteApp`
+  - Does it have a specific entry file (e.g., `src/index.ts`, `server.js`) and a `build` script that compiles TypeScript? → use `AddNodeApp` with `.WithRunScript()` and `.WithBuildScript()`
+  - Otherwise → use `AddJavaScriptApp`
+- **Monorepo/workspace detection**: Check root `package.json` for `"workspaces"` field (Yarn/npm) or `pnpm-workspace.yaml` (pnpm). If this is a monorepo:
+  - **Map workspace packages** — each workspace with a runnable script (`start`, `dev`) is a potential Aspire resource
+  - **Root scripts that delegate** — some monorepos have root-level scripts like `"start": "yarn --cwd ./subdir start"`. Model the *actual app directory* as the resource, not the root
+  - **Path resolution** — `appDirectory` is relative to the AppHost location. In monorepos you often need `../`, `../../`, or similar paths. Double-check these
+  - **Shared dependencies** — `.WithYarn()` / `.WithPnpm()` on each resource handles workspace-aware installs automatically
+- **Python apps**: directories with `pyproject.toml`, `requirements.txt`, or `main.py`/`app.py`
+- **Go apps**: directories with `go.mod`
+- **Java apps**: directories with `pom.xml` or `build.gradle`
+- **Dockerfiles**: standalone `Dockerfile` entries representing services
+- **Docker Compose**: `docker-compose.yml` or `compose.yml` files — these are a goldmine. Parse them to extract:
+  - **Profiles**: if any service has a `profiles:` key, the compose file uses profiles to organize services into groups (e.g., `cloud`, `storage`, `mssql`, `postgres`). When profiles exist:
+    1. List the available profiles and what services each includes
+    2. Ask the user which profile(s) to target for the AppHost (e.g., *"Your docker-compose uses profiles: cloud, mssql, postgres, storage, redis. Which represent your local dev stack?"*)
+    3. Only model services that belong to the selected profile(s) — skip the rest
+    4. If a service has no `profiles:` key, it runs in all profiles — always include it
+  - **Services**: each named service (in the selected profiles) maps to a potential AppHost resource
+  - **Images**: container images used (e.g., `postgres:16`, `redis:7`) → these become `AddContainer()` or typed Aspire integrations (e.g., `AddPostgres()`, `AddRedis()`)
+  - **Ports**: published port mappings → `WithHttpsEndpoint()` or `WithEndpoint()`
+  - **Environment variables**: env vars and `.env` file references → `WithEnvironment()`. Watch for `${VAR}` interpolation syntax — trace these back to `.env` files and migrate them to AppHost parameters
+  - **Volumes**: named/bind volumes → `WithVolume()` or `WithBindMount()`
+  - **Dependencies**: `depends_on` → `WithReference()` and `WaitFor()`
+  - **Build contexts**: `build:` entries → `AddDockerfile()` pointing to the build context directory
+  - Prefer typed Aspire integrations over raw `AddContainer()` when the image matches a known integration (use `aspire docs search` to check). For example, `postgres:16` → `AddPostgres()`, `redis:7` → `AddRedis()`, `rabbitmq:3` → `AddRabbitMQ()`.
+  - For complex compose files, also load [references/docker-compose.md](references/docker-compose.md) for detailed migration patterns.
+- **Static frontends**: Vite, Next.js, Create React App, or other frontend framework configs
+- **`.env` files**: Scan for `.env`, `.env.local`, `.env.development`, `.env.example`, etc. These contain configuration that should be migrated into AppHost parameters (see Guiding Principles above)
+- **User Secrets**: Scan for `secrets.json.example` files and `<UserSecretsId>` in `.csproj` files. These indicate .NET User Secrets are in use — migrate them into AppHost parameters (see Guiding Principles above)
+- **Package manager**: Detect which Node.js package manager the repo uses by looking for lock files: `pnpm-lock.yaml` → pnpm, `yarn.lock` → yarn, `package-lock.json` or none → npm. Use the detected package manager for all install/run commands throughout this skill.
+
+**Ignore:**
+
+- The AppHost directory/file itself
+- `node_modules/`, `.modules/`, `dist/`, `build/`, `bin/`, `obj/`, `.git/`
+- Test projects (directories named `test`/`tests`/`__tests__`, projects referencing xUnit/NUnit/MSTest, or test-only package.json scripts)
+
+### Step 2: Check prerequisites and smoke-test the skeleton
+
+Before investing time in wiring, run `aspire doctor` to verify the environment is ready:
+
+```bash
+aspire doctor
+```
+
+This checks for a working .NET SDK, container runtime (Docker/Podman), trusted dev certificates, and deprecated workloads. **Fix any failures before proceeding** — discovering that Docker isn't running *after* you've wired 10 services wastes significant time.
+
+Common issues caught by `aspire doctor`:
+- **Container runtime not running**: Start Docker Desktop or Podman before proceeding — container resources will fail to start without it.
+- **Deprecated aspire workload installed**: If installed by Visual Studio, it can't be removed via CLI — this is a warning, not a blocker.
+- **Untrusted dev certificate**: Run `aspire certs trust` to fix HTTPS endpoint failures.
+
+Once the environment is clean, verify the Aspire skeleton boots:
+
+```bash
+aspire start
+```
+
+The empty AppHost should start successfully — the dashboard should come up and the process should run without errors. You won't see any resources yet (that's expected), but if `aspire start` fails here, fix the issue before proceeding.
+
+For full project mode, the AppHost was created from the `aspire-apphost` template and should work out of the box. If it fails, common causes are:
+
+- **SDK version mismatch**: The repo's root `global.json` may pin an older SDK (e.g., 8.0). The AppHost directory needs its own nested `global.json` pinning the Aspire-supported SDK. Create one if missing (see Critical Rules above).
+- **Port conflicts**: If another Aspire app is running, the randomly assigned ports may conflict. Stop other instances first.
+
+For single-file mode:
+
+- **Missing profiles in `aspire.config.json`**: The file must have a `profiles` section with `applicationUrl`. Re-run `aspire init` to regenerate.
+- **Missing dependencies**: For TypeScript, ensure the `.modules/aspire.js` SDK is available. Run `aspire restore` if needed.
+
+Once it boots, stop it (Ctrl+C) and continue.
+
+### Step 3: Present findings and confirm with the user
+
+Show the user what you found. For each discovered project/service, show:
+
+- Name (project or directory name)
+- Type (.NET service, Node.js app, Python app, Dockerfile, etc.)
+- Framework/runtime info (e.g., net10.0, Node 20, Python 3.12)
+- Whether it exposes HTTP endpoints
+
+Ask the user:
+
+1. Which projects to include in the AppHost (pre-select all discovered runnable services)
+2. For C# AppHosts: which .NET projects should receive ServiceDefaults references (pre-select all .NET services)
+
+### Step 4: Create ServiceDefaults (C# only)
+
+> **Skip this step for TypeScript AppHosts.** OTel is handled in Step 8.
+
+If the AppHost is in **full project mode**, consult [references/full-solution-apphosts.md](references/full-solution-apphosts.md) before making ServiceDefaults changes. Some existing solutions need bootstrap updates before `AddServiceDefaults()` and `MapDefaultEndpoints()` can be applied safely.
+
+**Before creating ServiceDefaults, check for existing observability setup.** Many repos already have their own OpenTelemetry, Polly (HTTP resilience), or health check wiring — often in a shared extension method or SDK package. Search for:
+
+- `AddOpenTelemetry`, `UseOpenTelemetry`, `AddTracing`, `WithTracing`, `WithMetrics` — existing OTel setup
+- `AddStandardHttp`, `AddPolicyHandler`, `AddHttpStandardResilienceHandler` — existing Polly/resilience config
+- `AddHealthChecks`, `MapHealthChecks` — existing health check registration
+- Custom SDK extensions (e.g., `UseBitwardenSdk()`, `UseCompanySdk()`) — these often bundle OTel, health checks, and auth in one call
+
+If the repo already has OTel/health checks/resilience in a shared extension, **strip those from the generated ServiceDefaults** to avoid duplication. Only keep the parts that don't overlap. For example, if `UseBitwardenSdk()` already sets up OTel tracing and metrics, the ServiceDefaults should skip the OTel builder calls and only add service discovery and health endpoint mapping.
+
+Present the overlap to the user: *"Your services already set up OpenTelemetry via `UseBitwardenSdk()`. I'll create ServiceDefaults without the OTel setup to avoid duplication."*
+
+**Placement is your decision.** Where to put ServiceDefaults depends on the repo's structure:
+
+- If the AppHost has its own nested SDK boundary (nested `global.json`), ServiceDefaults should live next to the AppHost in that same boundary so it can target the same TFM.
+- If the repo's root SDK is compatible with the AppHost's TFM, ServiceDefaults can live alongside existing source (e.g., in `src/`).
+- If a ServiceDefaults project already exists (look for references to `Microsoft.Extensions.ServiceDiscovery` or `Aspire.ServiceDefaults`), skip creation and use the existing one.
+
+To create one:
+
+```bash
+dotnet new aspire-servicedefaults -n <SolutionName>.ServiceDefaults -o <path>
+```
+
+If a `.sln` exists and the ServiceDefaults project is compatible with the solution's SDK, add it:
+
+```bash
+dotnet sln <solution> add <ServiceDefaults.csproj>
+```
+
+### Step 5: Wire up the AppHost
+
+Edit the skeleton AppHost file to add resource definitions for each selected project. Use the appropriate syntax based on language.
+
+#### TypeScript AppHost (`apphost.ts`)
+
+```typescript
+import { createBuilder } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+
+// Express/Node.js API with TypeScript — needs build for publish
+const api = await builder
+    .addNodeApp("api", "./api", "dist/index.js")   // production entry point
+    .withRunScript("start:dev")                      // dev: runs ts-node-dev or similar
+    .withBuildScript("build")                        // publish: compiles TS first
+    .withYarn()                                      // or .withPnpm() — match the repo
+    .withHttpsDeveloperCertificate()
+    .withHttpsEndpoint({ env: "PORT" });
+
+// Vite frontend — HTTPS with dev cert, suppress auto-browser
+const frontend = await builder
+    .addViteApp("frontend", "./frontend")
+    .withBuildScript("build")
+    .withYarn()
+    .withHttpsDeveloperCertificate()
+    .withEnvironment("BROWSER", "none")              // prevent auto-opening browser
+    .withReference(api)
+    .waitFor(api);
+
+// .NET project — HTTPS works out of the box
+const dotnetSvc = await builder
+    .addCSharpApp("catalog", "./src/Catalog");
+
+// Dockerfile-based service
+const worker = await builder
+    .addDockerfile("worker", "./worker");
+
+// Python app — HTTPS with dev cert
+const pyApi = await builder
+    .addPythonApp("py-api", "./py-api", "app.py")
+    .withHttpsDeveloperCertificate();
+
+await builder.build().run();
+```
+
+#### C# AppHost — single-file mode (`apphost.cs`)
+
+```csharp
+#:sdk Aspire.AppHost.Sdk@<version>
+#:property IsAspireHost=true
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+var api = builder.AddCSharpApp("api", "../src/Api");
+
+var web = builder.AddCSharpApp("web", "../src/Web")
+    .WithReference(api)
+    .WaitFor(api);
+
+builder.Build().Run();
+```
+
+#### C# AppHost — full project mode (`Program.cs` + `.csproj`)
+
+In full project mode the AppHost has a `.csproj`, so prefer typed project references via `AddProject<T>()` — they give compile-time safety, auto-restart on rebuild, and the typed `Projects.*` namespace. Reserve `AddCSharpApp("name", "../path")` for cases where a project reference isn't possible (e.g., the service uses an SDK that can't be referenced from `Aspire.AppHost.Sdk`, or the AppHost is single-file mode).
+
+Edit the AppHost's `Program.cs`:
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+
+var api = builder.AddProject<Projects.Api>("api");
+
+var web = builder.AddProject<Projects.Web>("web")
+    .WithReference(api)
+    .WaitFor(api);
+
+builder.Build().Run();
+```
+
+And add project references so the `Projects.*` namespace is generated:
+
+```bash
+dotnet add <AppHost.csproj> reference <Api.csproj>
+dotnet add <AppHost.csproj> reference <Web.csproj>
+```
+
+#### Non-.NET services in a C# AppHost
+
+```csharp
+// Node.js app (Tier 1: Aspire.Hosting.JavaScript) — HTTPS with dev cert
+var frontend = builder.AddViteApp("frontend", "../frontend")
+    .WithHttpsDeveloperCertificate();
+
+// Python app (Tier 1: Aspire.Hosting.Python) — HTTPS with dev cert
+var pyApi = builder.AddPythonApp("py-api", "../py-api", "app.py")
+    .WithHttpsDeveloperCertificate();
+
+// Go app (Tier 2: CommunityToolkit.Aspire.Hosting.Golang)
+var goApi = builder.AddGolangApp("go-api", "../go-api")
+    .WithHttpsEndpoint(env: "PORT");
+
+// Dockerfile-based service (Tier 3: fallback for unsupported languages)
+var worker = builder.AddDockerfile("worker", "../worker");
+```
+
+Add required hosting packages — use `aspire add` or `dotnet add package`:
+
+```bash
+# Tier 1: first-party
+aspire add javascript    # or: dotnet add <AppHost.csproj> package Aspire.Hosting.JavaScript
+aspire add python        # or: dotnet add <AppHost.csproj> package Aspire.Hosting.Python
+
+# Tier 2: community toolkit
+aspire add communitytoolkit-golang
+# or: dotnet add <AppHost.csproj> package CommunityToolkit.Aspire.Hosting.Golang
+```
+
+Always check `aspire list integrations` and `aspire docs search "<language>"` to find the best available integration before falling back to `AddExecutable`/`AddDockerfile`.
+
+**Important rules:**
+
+- **Look up APIs before writing code** — see "Looking up APIs and integrations" section below. Do not guess API shapes.
+- Use meaningful resource names derived from the project/directory name.
+- Wire up `WithReference()`/`withReference()` and `WaitFor()`/`waitFor()` for services that depend on each other (ask the user if relationships are unclear).
+- Use `WithExternalHttpEndpoints()`/`withExternalHttpEndpoints()` for user-facing frontends.
+
+### Step 6: Configure dependencies
+
+#### TypeScript AppHost
+
+See [references/javascript-apps.md](references/javascript-apps.md) for `package.json`, `tsconfig.json`, and ESLint configuration patterns. Key points:
+
+- Augment existing files, never overwrite
+- Run `aspire restore` to generate `.modules/`, then install deps with the repo's package manager
+- Do not manually add Aspire SDK packages — `aspire restore` handles those
+
+#### C# AppHost
+
+**Full project mode**: dependencies are managed via the `.csproj` and `dotnet add package`/`dotnet add reference` (already handled in Steps 3-4).
+
+**Single-file mode**: dependencies are managed via `#:sdk` and `#:project` directives in the `apphost.cs` file.
+
+**NuGet feeds**: If `aspire.config.json` specifies a non-stable channel (preview, daily), ensure the appropriate NuGet feed is configured. For single-file mode this is automatic; for project mode, ensure a `NuGet.config` is in scope.
+
+### Step 7: Add ServiceDefaults to .NET projects (C# AppHost only)
+
+> **Skip this step for TypeScript AppHosts.**
+
+If any selected .NET service still uses a legacy `IHostBuilder` / `Startup.cs` bootstrap, consult [references/full-solution-apphosts.md](references/full-solution-apphosts.md) before editing it. Do not assume ServiceDefaults can be dropped into old hosting patterns unchanged.
+
+For each .NET project that the user selected for ServiceDefaults:
+
+```bash
+dotnet add <Project.csproj> reference <ServiceDefaults.csproj>
+```
+
+Then check each project's `Program.cs` (or equivalent entry point) and add if not already present:
+
+```csharp
+builder.AddServiceDefaults();  // Add early, after builder creation
+```
+
+And before `app.Run()`:
+
+```csharp
+app.MapDefaultEndpoints();
+```
+
+Be careful with code placement — look at existing structure (top-level statements vs `Startup.cs` vs `Program.Main`). Do not duplicate if already present.
+
+### Step 8: Wire up OpenTelemetry
+
+For .NET services, ServiceDefaults handles OTel automatically. For everything else, the services need a small setup to export telemetry. Aspire automatically injects `OTEL_EXPORTER_OTLP_ENDPOINT` into all managed resources — the services just need to read it.
+
+**Present this to the user as an option, not a mandatory step.** Some users may want to add OTel later, and that's fine — their services will still run, they just won't appear in the dashboard's trace/metrics views.
+
+**For each service that doesn't already have OTel, ask:**
+> "Would you like me to add OpenTelemetry instrumentation to `<service>`? This lets the Aspire dashboard show its traces, metrics, and logs. I'll need to add a few packages and an instrumentation setup file."
+
+If they say yes, follow the per-language setup guides in [references/opentelemetry.md](references/opentelemetry.md).
+
+### Step 9: Offer dev experience enhancements
+
+Before validating, present the user with optional quality-of-life improvements. These aren't required for `aspire start` to work, but they make the local dev experience significantly nicer.
+
+**Suggest each of these individually — don't apply without asking:**
+
+1. **Cookie and session isolation with `dev.localhost`**: When multiple services run on `localhost`, they share cookies and session storage — which can cause hard-to-debug auth problems. Using `*.dev.localhost` subdomains isolates each service's cookies and storage. Note: URLs still include ports (e.g., `frontend.dev.localhost:5173`), but the subdomain isolation prevents cross-service cookie collisions.
+   > "Would you like me to set up `dev.localhost` subdomains for your services? This gives each service its own cookie/session scope so they don't interfere with each other. URLs will look like `frontend.dev.localhost:5173` — the `*.dev.localhost` domain resolves to 127.0.0.1 automatically on most systems, no `/etc/hosts` changes needed."
+
+   **How to do it — pick the right config file based on AppHost mode** (see "Configuration files — which is which" earlier in this doc):
+
+   - **Single-file mode** (`apphost.cs` with `#:sdk` directive) and **polyglot AppHosts** (TypeScript, Python, Go, …): edit the `profiles` section in `aspire.config.json` at the repo root.
+   - **Full project mode** (`.csproj` AppHost): edit `Properties/launchSettings.json` inside the AppHost project directory. **Do not edit `aspire.config.json` for project-mode AppHosts** — they read launch profiles from `launchSettings.json`, so changes to `aspire.config.json` will be ignored.
+
+   In both cases, replace `localhost` with `<projectname>.dev.localhost` in `applicationUrl`, and use descriptive subdomains like `otlp.dev.localhost` and `resources.dev.localhost` for the infrastructure URLs. This is the same mechanism `aspire new` uses.
+
+   Example — `aspire.config.json` (single-file / polyglot):
+
+   ```json
+   {
+     "profiles": {
+       "https": {
+         "applicationUrl": "https://myproject.dev.localhost:17042;http://myproject.dev.localhost:15042",
+         "environmentVariables": {
+           "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://otlp.dev.localhost:21042",
+           "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://resources.dev.localhost:22042"
+         }
+       }
+     }
+   }
+   ```
+
+   Equivalent — `Properties/launchSettings.json` (full project mode):
+
+   ```json
+   {
+     "profiles": {
+       "https": {
+         "commandName": "Project",
+         "applicationUrl": "https://myproject.dev.localhost:17042;http://myproject.dev.localhost:15042",
+         "environmentVariables": {
+           "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://otlp.dev.localhost:21042",
+           "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://resources.dev.localhost:22042"
+         }
+       }
+     }
+   }
+   ```
+
+   Use the project/repo name (lowercased) as the subdomain prefix for `applicationUrl`. Use `otlp` and `resources` for the infrastructure URLs. Keep the existing port numbers — just swap `localhost` for the appropriate `*.dev.localhost` subdomain.
+
+2. **Custom URL labels in the dashboard** (display text only): Rename endpoint URLs in the Aspire dashboard for clarity:
+   ```csharp
+   .WithUrlForEndpoint("https", url => url.DisplayText = "Web UI")
+   ```
+
+3. **OpenTelemetry** (if not done in Step 8): "Would you like me to add observability to your services so they appear in the Aspire dashboard's traces and metrics views?"
+
+Present these as a batch: "I have a few optional dev experience improvements I can make. Want to hear about them?"
+
+### Step 10: Validate
+
+```bash
+aspire start
+```
+
+Once the app is running, use the Aspire CLI to verify everything is wired up correctly:
+
+1. **Resources are modeled**: `aspire describe` — confirm all expected resources appear with correct types, endpoints, and states.
+2. **Environment flows correctly**: `aspire describe` — check that environment variables (connection strings, ports, secrets from parameters) are injected into each resource as expected. Verify `.env` values that were migrated to parameters are present.
+3. **OTel is flowing** (if configured in Step 8): `aspire otel` — verify that services instrumented with OpenTelemetry are exporting traces and metrics to the Aspire dashboard collector.
+4. **No startup errors**: `aspire logs <resource>` — check logs for each resource to ensure clean startup with no crashes, missing config, or connection failures.
+5. **Dashboard is accessible**: Confirm the dashboard URL is printed and can be opened (remember: include the login token — see "Dashboard URL must include auth token" above).
+6. **Telemetry reaches the dashboard**: After resources are running, verify that traces and structured logs appear in the Aspire dashboard. Open the dashboard, navigate to the Traces view, and confirm at least one trace is visible from a service. If no telemetry flows:
+   - Check whether the service's OTel setup conditionally disables export (e.g., based on a `selfHosted` flag, a config key like `OpenTelemetry:Enabled`, or an environment check). Many SDKs default OTel OFF for self-hosted/local modes — set the enabling flag explicitly via `WithEnvironment()`.
+   - Check that `OTEL_EXPORTER_OTLP_ENDPOINT` is being injected by Aspire (it should be automatic for services modeled with `AddCSharpApp`/`AddProject`).
+   - Generate a trace by making an HTTP request to one of the services (e.g., `curl https://localhost:<port>/healthz` or any known endpoint). Some services don't emit traces until they receive traffic.
+   - Check service logs for OTLP exporter errors (connection refused, TLS handshake failures).
+
+**This skill is not done until `aspire start` runs without errors and every resource is in an expected terminal/runtime state.** Acceptable end states are:
+
+- **Healthy / Running** for long-lived services
+- **Finished** only for resources that were intentionally modeled as one-shot tasks (for example migrations or seed steps) **and** only if they exited cleanly with no errors
+- **Not started** only when that is intentional and understood (for example, an optional resource the user chose not to run yet)
+
+Treat these as failure states unless you intentionally designed for them:
+
+- **Finished** for long-lived APIs, frontends, workers, or databases
+- **Finished** after an exception, crash, or non-zero exit
+- unhealthy, degraded, failed, or crash-looping resources
+
+If anything lands in an unexpected state, diagnose it, fix it, and run `aspire start` again. Keep iterating until the app behaves as expected — do not move on to Step 11 with crash-shaped "success".
+
+Once everything is healthy, print a summary for the user:
+
+```
+✅ Aspire init complete!
+
+Dashboard: <full dashboard URL including login token>
+
+Resources:
+  <name>  <type>  <status>
+  <name>  <type>  <status>
+  ...
+
+<any notes about optional steps skipped, e.g., "OTel not configured — run the aspire skill to add it later">
+```
+
+Get the dashboard URL (with login token) from `aspire start` output. Get resource status from `aspire describe`. If any resource shows `Finished`, confirm from logs that it was an intentional one-shot resource that exited successfully before including it as success. This summary is the user's confirmation that init worked — make it complete and accurate.
+
+Common issues:
+
+- **TypeScript**: missing dependency install, TS compilation errors, port conflicts
+- **C# project mode**: missing project references, NuGet restore needed, TFM mismatches, build errors
+- **C# single-file**: `#:project` paths wrong, missing SDK directive
+- **Both**: missing environment variables, port conflicts
+- **Certificate errors**: if HTTPS fails, run `aspire certs trust` and retry
+
+### Step 11: Update solution file (C# full project mode only)
+
+If a `.sln`/`.slnx` exists, verify all new projects are included:
+
+```bash
+dotnet sln <solution> list
+```
+
+Ensure both the AppHost and ServiceDefaults projects appear.
+
+### Step 12: Clean up
+
+After successful validation:
+
+1. **Leave the AppHost running** — the user gets a fully running app with the dashboard open. Do not call `aspire stop`.
+2. Confirm the evergreen `aspire` skill is present for ongoing AppHost work.
+3. Do not delete the `aspireify/` skill directory unless the user explicitly asks.
+
+## Key rules
+
+- **Never overwrite existing files** — always augment/merge
+- **Ask the user before modifying service code** (especially OTel and ServiceDefaults injection)
+- **Respect existing project structure** — don't reorganize the repo
+- **If stuck, use `aspire doctor`** to diagnose environment issues
+- **Never hardcode URLs in `withEnvironment`** — when a service needs another service's URL (e.g., `VITE_APP_WS_SERVER_URL`), pass an endpoint reference, NOT a string literal. Use `room.getEndpoint("http")` (TS) or `room.GetEndpoint("http")` (C#) and pass that to `withEnvironment`. Hardcoded URLs break when ports change.
+- **Never use `withUrlForEndpoint` to set `dev.localhost` URLs** — `dev.localhost` configuration belongs in `aspire.config.json` profiles, not in AppHost code. `withUrlForEndpoint` is ONLY for setting display labels (e.g., `url.DisplayText = "Web UI"`).
+
+## References
+
+- For AppHost wiring patterns, API lookup, endpoint configuration, and resource wiring, see [references/apphost-wiring.md](references/apphost-wiring.md).
+- For solution-backed C# AppHosts (`.sln`/`.slnx` + `.csproj` AppHost), see [references/full-solution-apphosts.md](references/full-solution-apphosts.md).
+- For repos with `docker-compose.yml` or `compose.yml`, see [references/docker-compose.md](references/docker-compose.md).
+- For per-language OpenTelemetry setup (Node, Python, Go, Java), see [references/opentelemetry.md](references/opentelemetry.md).
+- For JavaScript/TypeScript resource types, dev scripts, and TypeScript AppHost config, see [references/javascript-apps.md](references/javascript-apps.md).

--- a/.agents/skills/aspireify/references/apphost-wiring.md
+++ b/.agents/skills/aspireify/references/apphost-wiring.md
@@ -1,0 +1,393 @@
+# AppHost wiring and API lookup reference
+
+Use this reference when writing Step 5 (Wire up the AppHost) or when you need to look up Aspire APIs, integration packages, or wiring patterns.
+
+> **⚠️ Always look up APIs before writing code.** Do not guess builder method names or parameter shapes. Use `aspire docs search "<topic>"` and `aspire docs get "<slug>"` for documented patterns, then `aspire docs api search "<query>" --language csharp|typescript` and `aspire docs api get "<id>"` to confirm the exact reference entry for the API you are about to call.
+
+## Looking up APIs and integrations
+
+Before writing AppHost code for an unfamiliar resource type or integration, **always** look it up. **Do not assume APIs exist or guess their shapes** — Aspire has many resource types with specific overloads.
+
+### Tiered preference for modeling resources
+
+#### Tier 1: First-party Aspire hosting packages (always prefer)
+
+Packages named `Aspire.Hosting.*` — maintained by the Aspire team and ship with every release. Examples:
+
+| Package | Unlocks |
+|---------|---------|
+| `Aspire.Hosting.Python` | `AddPythonApp()`, `AddUvicornApp()` |
+| `Aspire.Hosting.JavaScript` | `AddJavaScriptApp()`, `AddNodeApp()`, `AddViteApp()`, `.WithYarn()`, `.WithPnpm()` |
+| `Aspire.Hosting.PostgreSQL` | `AddPostgres()`, `AddDatabase()` |
+| `Aspire.Hosting.Redis` | `AddRedis()` |
+
+#### Tier 2: Community Toolkit packages (use when no first-party exists)
+
+Packages named `CommunityToolkit.Aspire.Hosting.*` — maintained by the community, documented on aspire.dev, and installable via `aspire add`. Examples:
+
+| Package | Unlocks |
+|---------|---------|
+| `CommunityToolkit.Aspire.Hosting.Golang` | `AddGolangApp()` — handles `go run .`, working dir, PORT env |
+| `CommunityToolkit.Aspire.Hosting.Rust` | `AddRustApp()` |
+| `CommunityToolkit.Aspire.Hosting.Java` | Java hosting support |
+
+These provide typed APIs with proper endpoint handling, health checks, and dashboard integration — significantly better than raw executables.
+
+#### Tier 3: Raw fallbacks (last resort)
+
+`AddExecutable()`, `AddDockerfile()`, `AddContainer()` — use only when no Tier 1 or Tier 2 package exists for the technology, or when the user's setup is too custom for a typed integration.
+
+### How to discover available packages
+
+```bash
+# Search for documentation on a topic
+aspire docs search "redis"
+aspire docs search "golang"
+aspire docs search "python uvicorn"
+
+# Get a specific doc page by slug (returned from search results)
+aspire docs get "redis-integration"
+aspire docs get "go-integration"
+
+# Find the exact C# / TypeScript API reference entry for a builder method
+aspire docs api search "AddRedis" --language csharp
+aspire docs api search "AddViteApp" --language typescript
+aspire docs api get "<id-from-api-search>"
+
+# List ALL available integrations (first-party and community toolkit)
+# Note: requires the Aspire MCP server to be connected. If this fails, use aspire docs search instead.
+aspire list integrations
+```
+
+Use `aspire docs search` / `aspire docs get` to find the right builder methods, configuration options, and patterns. Use `aspire docs api search` / `aspire docs api get` when you need the exact reference entry (parameter shapes, return types, overloads) for the API you are about to call. Use `aspire list integrations` to discover packages you might not have known about.
+
+**Don't invent APIs** — if docs search and integration list don't return it, it doesn't exist. Fall back to Tier 3 and note the limitation to the user. **API shapes differ between C# and TypeScript** — always check the correct language docs.
+
+### Check what integrations auto-manage
+
+Before modeling environment variables, passwords, ports, or volumes for a typed integration, **check the docs to see what the integration handles automatically**. Many typed integrations auto-generate passwords, manage ports dynamically, and handle volumes — duplicating this config causes errors or conflicts.
+
+```bash
+# Check what AddPostgres manages automatically
+aspire docs get "postgresql-hosting-integration" --section "Connection properties"
+
+# Check what AddSqlServer manages
+aspire docs get "sql-server-integration" --section "Hosting integration"
+```
+
+Look for the **"Connection properties"** section — it lists what the integration injects into consuming services. If it lists `Password`, `Host`, `Port` — the integration manages those. Do not create `AddParameter()` for values the integration already handles.
+
+Common auto-managed values (do NOT model these manually):
+
+| Integration | Auto-managed |
+|-------------|-------------|
+| `AddPostgres()` | Password, host, port, connection string |
+| `AddSqlServer()` | SA password, host, port, connection string |
+| `AddRedis()` | Connection string, port |
+| `AddMySql()` | Root password, host, port, connection string |
+| `AddRabbitMQ()` | Username, password, host, port, connection string |
+| `AddMongoDB()` | Connection string, port |
+
+To add an integration package (which unlocks typed builder methods):
+
+```bash
+# First-party
+aspire add redis
+aspire add python
+aspire add nodejs
+
+# Community Toolkit
+aspire add communitytoolkit-golang
+aspire add communitytoolkit-rust
+```
+
+After adding, run `aspire restore` (TypeScript) or `dotnet restore` (C#) to update available APIs, then check what methods are now available.
+
+**Always prefer a typed integration over raw `AddExecutable`/`AddContainer`.** Typed integrations handle working directories, port injection, health checks, and dashboard integration automatically.
+
+## Service communication: `WithReference` vs `WithEnvironment`
+
+**`WithReference()`** is the primary way to connect services. It does two things:
+
+1. Injects the referenced resource's connection information (connection string or URL) into the consuming service
+2. Enables Aspire service discovery — .NET services can resolve the referenced resource by name
+
+```csharp
+// C#: api gets the database connection string injected automatically
+var db = builder.AddPostgres("pg").AddDatabase("mydb");
+var api = builder.AddCSharpApp("api", "../src/Api")
+    .WithReference(db);
+
+// C#: frontend gets service discovery URL for api
+var frontend = builder.AddCSharpApp("web", "../src/Web")
+    .WithReference(api);
+```
+
+```typescript
+// TypeScript equivalent
+const db = await builder.addPostgres("pg").addDatabase("mydb");
+const api = await builder.addCSharpApp("api", "./src/Api")
+    .withReference(db);
+```
+
+**How services consume references**: Services receive connection info as environment variables. The naming convention is:
+- Connection strings: `ConnectionStrings__<resourceName>` (e.g., `ConnectionStrings__mydb=Host=...`)
+- Service URLs: `services__<resourceName>__<endpointName>__0` (e.g., `services__api__http__0=http://localhost:5123`)
+
+**`WithEnvironment()`** injects raw environment variables. Use this for custom config that isn't a service reference:
+
+```csharp
+var api = builder.AddCSharpApp("api", "../src/Api")
+    .WithEnvironment("FEATURE_FLAG_X", "true")
+    .WithEnvironment("API_KEY", someParameter);
+```
+
+**When to use which:**
+- Connecting service A to service B or a database/cache/queue → `WithReference()`
+- Passing configuration values, feature flags, API keys → `WithEnvironment()`
+- Never manually construct connection strings with `WithEnvironment()` when `WithReference()` would work
+
+## Endpoints and ports
+
+**Prefer HTTPS by default.** Use `WithHttpsEndpoint()` for all services and fall back to `WithHttpEndpoint()` only if HTTPS doesn't work for that resource.
+
+**Prefer Aspire-managed ports by default.** For most local development scenarios, let Aspire assign the port and inject it into the service. This avoids port collisions, makes multiple AppHosts easier to run side-by-side, and keeps cross-service wiring flexible.
+
+**Ask before pinning a fixed port.** If the repo already uses a hardcoded port, do **not** silently preserve it just because it exists. Ask whether that port is actually required. Good reasons to keep a fixed port include:
+
+- OAuth/callback URLs or external webhooks that expect a stable local address
+- Browser extensions or desktop/mobile clients that are already hardcoded to a specific port
+- Repo docs, scripts, or test tooling that explicitly depend on that exact port
+
+If none of those apply, steer the user toward managed ports.
+
+**`WithHttpsEndpoint()`** — expose an HTTPS endpoint. For services that serve traffic:
+
+```csharp
+// Let Aspire assign a random port (recommended for most cases)
+var api = builder.AddCSharpApp("api", "../src/Api")
+    .WithHttpsEndpoint();
+
+// Use a specific port only when the user confirms it is required
+var api = builder.AddCSharpApp("api", "../src/Api")
+    .WithHttpsEndpoint(port: 5001);
+
+// For services that read the port from an env var
+var nodeApi = builder.AddJavaScriptApp("api", "../api", "start")
+    .WithHttpsDeveloperCertificate()
+    .WithHttpsEndpoint(env: "PORT");  // Aspire injects PORT=<assigned-port>
+```
+
+**`WithHttpsDeveloperCertificate()`** — required for JavaScript and Python apps to serve HTTPS. Configures the ASP.NET Core dev cert. .NET apps handle this automatically.
+
+```csharp
+var frontend = builder.AddViteApp("frontend", "../frontend")
+    .WithHttpsDeveloperCertificate();
+
+var pyApi = builder.AddUvicornApp("api", "../api", "app:main")
+    .WithHttpsDeveloperCertificate();
+```
+
+> If `WithHttpsDeveloperCertificate()` causes issues for a resource, fall back to `WithHttpEndpoint()` and leave a comment explaining why.
+
+**`WithHttpEndpoint()`** — fallback for HTTP when HTTPS doesn't work:
+
+```csharp
+// Use when HTTPS causes issues with a specific integration
+var legacy = builder.AddJavaScriptApp("legacy", "../legacy", "start")
+    .WithHttpEndpoint(env: "PORT");  // HTTP fallback
+```
+
+**`WithEndpoint()`** — expose a non-HTTP endpoint (gRPC, TCP, custom protocols):
+
+```csharp
+var grpcService = builder.AddCSharpApp("grpc", "../src/GrpcService")
+    .WithEndpoint("grpc", endpoint =>
+    {
+        endpoint.Port = 5050;
+        endpoint.Protocol = "grpc";
+    });
+```
+
+**`WithExternalHttpEndpoints()`** — mark a resource's HTTP endpoints as externally visible. Use this for user-facing frontends so the URL appears prominently in the dashboard:
+
+```csharp
+var frontend = builder.AddViteApp("frontend", "../frontend")
+    .WithHttpsDeveloperCertificate()
+    .WithHttpsEndpoint(env: "PORT")
+    .WithExternalHttpEndpoints();
+```
+
+**Port injection**: Many frameworks (Express, Vite, Flask) need to know which port to listen on. Use the `env:` parameter:
+- `withHttpsEndpoint({ env: "PORT" })` (TypeScript)
+- `.WithHttpsEndpoint(env: "PORT")` (C#)
+
+Aspire assigns a port and injects it as the specified environment variable. The service should read it and listen on that port.
+
+**Recommended ask when a repo already hardcodes ports:**
+
+> "I found this service pinned to port 3000 today. Unless that exact port is needed for an external callback or another hard requirement, I recommend switching it to read PORT from env and letting Aspire manage the port. That avoids collisions and makes the AppHost more portable. Should I keep 3000 or make it Aspire-managed?"
+
+## Cross-service environment variable wiring
+
+When a service expects a **specific env var name** for a dependency's URL (not the standard `services__` format from `WithReference`), use `WithEnvironment` with an endpoint reference — **never a hardcoded string**:
+
+```typescript
+// ✅ CORRECT — endpoint reference resolves to the actual URL at runtime
+const roomEndpoint = await room.getEndpoint("http");
+
+const frontend = await builder
+    .addViteApp("frontend", "./frontend")
+    .withEnvironment("VITE_APP_WS_SERVER_URL", roomEndpoint)  // EndpointReference, not a string
+    .withReference(room)   // also sets up standard service discovery
+    .waitFor(room);
+
+// ❌ WRONG — hardcoded URL breaks when Aspire assigns different ports
+    .withEnvironment("VITE_APP_WS_SERVER_URL", "http://localhost:3002")  // NEVER DO THIS
+```
+
+```csharp
+// C# equivalent
+var roomEndpoint = room.GetEndpoint("http");
+var frontend = builder.AddViteApp("frontend", "../frontend")
+    .WithEnvironment("VITE_APP_WS_SERVER_URL", roomEndpoint)
+    .WithReference(room)
+    .WaitFor(room);
+```
+
+Use `WithEnvironment(name, endpointRef)` when the consuming service reads a **specific env var name**. Use `WithReference()` when the service uses Aspire service discovery or standard connection string patterns. You can use both together.
+
+## URL labels and dashboard niceties
+
+Customize how endpoints appear in the Aspire dashboard:
+
+```csharp
+// Named endpoints for clarity
+var api = builder.AddCSharpApp("api", "../src/Api")
+    .WithHttpsEndpoint(name: "public", port: 8443)
+    .WithHttpsEndpoint(name: "internal", port: 8444);
+```
+
+For `dev.localhost` cookie isolation and config-based subdomain setup, see Step 9 in the main SKILL.md.
+
+## Dependency ordering: `WaitFor` and `WaitForCompletion`
+
+**`WaitFor()`** — delay starting a resource until another resource is healthy/ready:
+
+```csharp
+var db = builder.AddPostgres("pg").AddDatabase("mydb");
+var api = builder.AddCSharpApp("api", "../src/Api")
+    .WithReference(db)
+    .WaitFor(db);  // Don't start api until db is healthy
+```
+
+Always pair `WithReference()` with `WaitFor()` for infrastructure dependencies (databases, caches, queues). Services that depend on other services should generally also wait for them.
+
+**`WaitForCompletion()`** — wait for a resource to run to completion (exit successfully). Use for init containers, database migrations, or seed data scripts:
+
+```csharp
+var migration = builder.AddCSharpApp("migration", "../src/MigrationRunner")
+    .WithReference(db)
+    .WaitFor(db);
+
+var api = builder.AddCSharpApp("api", "../src/Api")
+    .WithReference(db)
+    .WaitFor(db)
+    .WaitForCompletion(migration);  // Don't start until migration finishes
+```
+
+## Secrets in process arguments — avoid `WithArgs` for sensitive values
+
+**⚠️ Never pass connection strings, passwords, or other secrets via `WithArgs()`.** Process arguments are visible in task managers, `ps` output, process inspection tools, and often end up in logs. This is a secret leakage risk.
+
+```csharp
+// ❌ WRONG — connection string visible in process arguments
+var migrator = builder.AddCSharpApp("migrator", "../util/Migrator")
+    .WithArgs(context =>
+    {
+        context.Args.Add(db.Resource.ConnectionStringExpression);
+    });
+
+// ✅ CORRECT — pass secrets via environment variables
+var migrator = builder.AddCSharpApp("migrator", "../util/Migrator")
+    .WithEnvironment("DB_CONNECTION_STRING", db.Resource.ConnectionStringExpression);
+```
+
+If the tool only accepts the connection string as a CLI argument (e.g., a third-party migration runner), note this limitation to the user and suggest modifying the tool to read from an environment variable or config file instead. If modification isn't possible, using `WithArgs` is acceptable as a pragmatic tradeoff — but flag it explicitly.
+
+## Container lifetimes
+
+By default, containers are stopped when the AppHost stops. Use **persistent lifetime** to keep containers running across restarts (useful for databases during development):
+
+```csharp
+var db = builder.AddPostgres("pg")
+    .WithLifetime(ContainerLifetime.Persistent);
+```
+
+This prevents data loss when restarting the AppHost — the container stays running and the AppHost reconnects.
+
+**TypeScript equivalent:**
+
+```typescript
+const db = await builder.addPostgres("pg")
+    .withLifetime("persistent");
+```
+
+Recommend persistent lifetime for databases and caches during local development.
+
+**⚠️ Stale persistent volumes can cause auth failures.** Typed integrations like `AddSqlServer()`, `AddPostgres()`, `AddRedis()`, and `AddMySql()` auto-generate passwords on first run. Those passwords are stored inside the container's data volume. If the AppHost is recreated or its user-secrets are reset, Aspire generates a *new* password — but the persistent volume still has the *old* one. The symptom is repeated `Login failed` or `password authentication failed` errors in the container logs.
+
+To fix: stop the AppHost, remove the stale container and its volume (`docker rm -f <name>; docker volume rm <volume>`), then restart. Aspire will recreate both with a matching password. Mention this to the user if they see auth failures on persistent infrastructure containers after recreating the AppHost.
+
+## Explicit start (manual start)
+
+Some resources shouldn't auto-start with the AppHost. Mark them for explicit start:
+
+```csharp
+var debugTool = builder.AddContainer("profiler", "myregistry/profiler")
+    .WithLifetime(ContainerLifetime.Persistent)
+    .ExcludeFromManifest()
+    .WithExplicitStart();
+```
+
+The resource appears in the dashboard but stays stopped until the user manually starts it. Useful for debugging tools, admin UIs, or optional services.
+
+## Parent resources (grouping in the dashboard)
+
+Group related resources under a parent for a cleaner dashboard:
+
+```csharp
+var postgres = builder.AddPostgres("pg");
+var ordersDb = postgres.AddDatabase("orders");
+var inventoryDb = postgres.AddDatabase("inventory");
+// ordersDb and inventoryDb appear nested under pg in the dashboard
+```
+
+This happens automatically for databases added to a server resource. For custom grouping of arbitrary resources, use `WithParentRelationship()`:
+
+```csharp
+var backend = builder.AddResource(new ContainerResource("backend-group"));
+var api = builder.AddCSharpApp("api", "../src/Api")
+    .WithParentRelationship(backend);
+var worker = builder.AddCSharpApp("worker", "../src/Worker")
+    .WithParentRelationship(backend);
+```
+
+Use `aspire docs search "parent relationship"` to verify the current API shape.
+
+## Volumes and data persistence
+
+```csharp
+// Named volume (managed by Docker, persists across container recreations)
+var db = builder.AddPostgres("pg")
+    .WithDataVolume("pg-data");
+
+// Bind mount (maps to a host directory)
+var db = builder.AddPostgres("pg")
+    .WithBindMount("./data/pg", "/var/lib/postgresql/data");
+```
+
+```typescript
+const db = await builder.addPostgres("pg")
+    .withDataVolume("pg-data");
+```

--- a/.agents/skills/aspireify/references/docker-compose.md
+++ b/.agents/skills/aspireify/references/docker-compose.md
@@ -1,0 +1,214 @@
+# Docker Compose migration
+
+Use this reference when the repo has a `docker-compose.yml` or `compose.yml` file. Docker Compose files are one of the most valuable discovery sources — they document the infrastructure the app actually needs to run locally.
+
+## When to load this reference
+
+- A `docker-compose.yml`, `compose.yml`, or `docker-compose.override.yml` exists anywhere in the repo
+- The repo has setup scripts that call `docker compose up` as part of the dev workflow
+
+## Profiles
+
+Docker Compose files can use `profiles:` to organize services into named groups. Not all services run at once — the developer chooses which profiles to activate.
+
+Example from a real repo:
+
+```yaml
+services:
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    profiles: [cloud, mssql]
+  postgres:
+    image: postgres:14
+    profiles: [postgres, ef]
+  redis:
+    image: redis:alpine
+    profiles: [redis, cloud]
+  storage:
+    image: mcr.microsoft.com/azure-storage/azurite:latest
+    profiles: [storage, cloud]
+  mail:
+    image: sj26/mailcatcher:latest
+    profiles: [mail]
+```
+
+When profiles are present:
+
+1. **List them clearly** — show the user which profiles exist and what services each activates
+2. **Ask which to target** — *"Your docker-compose has profiles: cloud, mssql, postgres, storage, redis, mail. Which ones represent your typical local dev stack?"*
+3. **Model only selected profiles** — services in unselected profiles are skipped entirely
+4. **Services without profiles always run** — if a service has no `profiles:` key, include it regardless of profile selection
+5. **Profile-specific infrastructure implies choices** — `mssql` vs `postgres` profiles often mean the repo supports multiple database backends. Ask which one to model in the AppHost.
+
+## Image-to-integration mapping
+
+Prefer typed Aspire integrations over raw `AddContainer()`. Use `aspire docs search <technology>` to check for available integrations.
+
+Common mappings:
+
+| Compose image | Aspire integration | Method |
+|---------------|-------------------|--------|
+| `postgres:*` | `Aspire.Hosting.PostgreSQL` | `AddPostgres()` |
+| `mcr.microsoft.com/mssql/server:*` | `Aspire.Hosting.SqlServer` | `AddSqlServer()` |
+| `mysql:*` / `mariadb:*` | `Aspire.Hosting.MySql` | `AddMySql()` |
+| `redis:*` | `Aspire.Hosting.Redis` | `AddRedis()` |
+| `rabbitmq:*` | `Aspire.Hosting.RabbitMQ` | `AddRabbitMQ()` |
+| `mongo:*` | `Aspire.Hosting.MongoDB` | `AddMongoDB()` |
+| `mcr.microsoft.com/azure-storage/azurite:*` | `Aspire.Hosting.Azure.Storage` | `AddAzureStorage().RunAsEmulator()` |
+| `kafka`, `confluentinc/cp-kafka:*` | `Aspire.Hosting.Kafka` | `AddKafka()` |
+| `nats:*` | `Aspire.Hosting.Nats` | `AddNats()` |
+| `mcr.microsoft.com/azure-messaging/servicebus-emulator:*` | `Aspire.Hosting.Azure.ServiceBus` | `AddAzureServiceBus().RunAsEmulator()` |
+
+For images not in this list, use `aspire docs search` to check, then fall back to `AddContainer()`.
+
+## Environment variable interpolation
+
+Compose files use `${VAR}` syntax to reference variables from `.env` files:
+
+```yaml
+environment:
+  MSSQL_SA_PASSWORD: ${MSSQL_PASSWORD}
+  POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+```
+
+**⚠️ CRITICAL: Do not model passwords for typed Aspire integrations.**
+
+`AddPostgres()`, `AddSqlServer()`, `AddRedis()`, `AddMySql()`, `AddRabbitMQ()`, and other typed integrations **auto-generate secure passwords**. The compose file needed `POSTGRES_PASSWORD` because Compose doesn't manage credentials — Aspire does. If you see a compose password variable that maps to a typed integration, **skip it entirely**. Do not create an `AddParameter` for it.
+
+```csharp
+// ❌ WRONG — don't model passwords that Aspire auto-generates
+var pgPassword = builder.AddParameter("postgres-password", secret: true);
+var postgres = builder.AddPostgres("postgres", password: pgPassword);
+
+// ✅ RIGHT — let Aspire handle the password
+var postgres = builder.AddPostgres("postgres");
+```
+
+Use `aspire docs get <integration-slug>` to check what each typed integration manages automatically. Look for the "Connection properties" section — if it lists `Password`, the integration handles it.
+
+When you see a `${VAR}` pattern in compose:
+
+1. **Check if it maps to a typed integration** — if `POSTGRES_PASSWORD`, `MSSQL_SA_PASSWORD`, `MYSQL_ROOT_PASSWORD`, `RABBITMQ_DEFAULT_PASS`, etc. are used by a typed Aspire integration, **skip them** — Aspire manages these
+2. **Trace non-integration variables** — find them in the `.env` or `.env.example` file
+3. **Classify** — is it a secret (API key, token) or plain config?
+4. **Model it** — secrets become `AddParameter(name, secret: true)`, plain config becomes `AddParameter(name)` with a default or `WithEnvironment()` directly
+
+## Volume mapping
+
+| Compose volume type | Aspire equivalent | Notes |
+|--------------------|--------------------|-------|
+| Named volume (`mssql_data:/var/opt/mssql`) | `WithDataVolume()` | Preferred — Aspire manages lifecycle |
+| Named volume (custom name) | `WithDataVolume(name: "custom")` | Preserves the name for familiarity |
+| Bind mount (`./data:/app/data`) | `WithBindMount("./data", "/app/data")` | Use for config files, scripts, or shared data |
+| Bind mount for config (`./config.json:/etc/config.json`) | `WithBindMount(...)` | Preserve for config injection |
+
+**Tip:** If the compose file mounts migration scripts or SQL files into a database container, those are likely init scripts. See "Init and setup scripts" below.
+
+## Dependency ordering
+
+Compose `depends_on` maps to Aspire's `WaitFor()`:
+
+```yaml
+# Compose
+services:
+  api:
+    depends_on:
+      - mssql
+      - redis
+```
+
+```csharp
+// Aspire
+var api = builder.AddProject<Projects.Api>("api")
+    .WithReference(mssql)
+    .WithReference(redis)
+    .WaitFor(mssql)
+    .WaitFor(redis);
+```
+
+`WithReference()` establishes the connection. `WaitFor()` ensures the dependency is healthy before the consuming service starts. Use both together.
+
+For `depends_on` with `condition: service_healthy`, the `WaitFor()` mapping is especially important — it replicates the same behavior.
+
+## Build contexts
+
+Compose services with `build:` are built from source, not pulled as images:
+
+```yaml
+services:
+  worker:
+    build:
+      context: ./worker
+      dockerfile: Dockerfile
+```
+
+Map these to `AddDockerfile()`:
+
+```csharp
+var worker = builder.AddDockerfile("worker", "../worker")
+    .WithHttpEndpoint(targetPort: 8080);
+```
+
+However, **prefer native Aspire project hosting over Dockerfiles when possible**. If the build context contains a `.csproj`, use `AddProject<T>()`. If it's a Node.js app, use `AddNodeApp()` or `AddViteApp()`. Dockerfiles are a last resort for Aspire modeling — they lose service discovery, health checks, and hot reload.
+
+## Init and setup scripts
+
+Repos often have setup scripts alongside their compose files:
+
+- `setup_azurite.ps1` — initializes storage emulator containers and queues
+- `migrate.ps1` / `ef_migrate.ps1` — runs database migrations
+- `setup_secrets.ps1` — configures .NET user secrets
+- `create_certificates_*.sh` — generates dev certificates
+
+**Present the user with options for how to handle these:**
+
+1. **Model as a lifecycle command on the relevant resource** — for example, a database migration script can be a startup command on the database resource. This runs automatically when the resource starts.
+   → *"Your repo has a migrate.ps1 that runs SQL migrations against the database. I can model this as a startup lifecycle hook on the database resource so migrations run automatically when you `aspire start`. Want that?"*
+
+2. **Model as a standalone executable resource** — for scripts that don't map cleanly to a single resource, use `AddExecutable()` with `WaitForCompletion()` so dependent services wait for the script to finish.
+
+3. **Leave as manual** — some setup scripts are one-time-only (like certificate generation) and don't need to run every time. Note them in the AppHost as a comment and move on.
+
+The right choice depends on the script. Present the tradeoff and let the user decide.
+
+## Putting it together
+
+A compose file like:
+
+```yaml
+services:
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      MSSQL_SA_PASSWORD: ${MSSQL_PASSWORD}
+    volumes:
+      - mssql_data:/var/opt/mssql
+    ports:
+      - "1433:1433"
+  redis:
+    image: redis:alpine
+    volumes:
+      - redis_data:/data
+    ports:
+      - "6379:6379"
+```
+
+Becomes:
+
+```csharp
+// ✅ Let Aspire auto-generate the SA password — don't model MSSQL_PASSWORD
+var mssql = builder.AddSqlServer("mssql")
+    .WithDataVolume();
+
+var redis = builder.AddRedis("redis")
+    .WithDataVolume();
+```
+
+Note: for typed integrations like `AddSqlServer()` and `AddRedis()`, you don't need to map ports or passwords — Aspire handles both. You also don't need to model `redis_data` as a named volume — `WithDataVolume()` handles persistence. The `${MSSQL_PASSWORD}` from the compose file is skipped entirely because `AddSqlServer()` auto-generates a secure SA password.
+
+## Common pitfalls
+
+- **Don't model every compose service** — some are dev-only tools (mailcatcher, reverse proxies, SAML IdPs for testing). Ask the user which are essential vs nice-to-have.
+- **Don't preserve hardcoded ports from compose** — Aspire manages ports dynamically. Only preserve a port if the user confirms it's required for external reasons (OAuth callbacks, etc.).
+- **Don't duplicate compose's `.env` interpolation** — Aspire parameters replace this pattern. Trace each `${VAR}` to its source and model it properly.
+- **Watch for services that conflict on the same port** — compose profiles often have services sharing ports (e.g., `mssql` and `postgres` both on different profiles). If the user selects conflicting profiles, surface the conflict.

--- a/.agents/skills/aspireify/references/full-solution-apphosts.md
+++ b/.agents/skills/aspireify/references/full-solution-apphosts.md
@@ -1,0 +1,332 @@
+# Full-solution C# AppHosts
+
+Use this reference when `aspire init` created a **full project mode** AppHost because a `.sln` or `.slnx` was discovered.
+
+This is the high-friction path: solution-backed repos often have older bootstrap patterns, SDK pins, existing ServiceDefaults-like code, build constraints, and significantly more projects than single-file repos. Some of these solutions have dozens or hundreds of projects — the skill must triage smartly, not try to wire everything.
+
+## What this reference is for
+
+Load this reference when any of the following are true:
+
+- `appHost.path` points to a directory containing `apphost.cs` and a `.csproj`
+- a `.sln` or `.slnx` exists near the AppHost
+- the repo has a root `global.json`
+- selected .NET services still use `Program.cs` + `Startup.cs`, `Host.CreateDefaultBuilder`, `ConfigureWebHostDefaults`, `UseStartup`, or other `IHostBuilder` patterns
+
+## Core rule: solution-backed AppHosts are not single-file AppHosts
+
+Treat these repos as **solution-aware C# init**, not as generic AppHost setup.
+
+- The AppHost may need project references
+- The AppHost may need its own SDK boundary
+- The solution may or may not be able to own the AppHost safely
+- ServiceDefaults changes may require bootstrap modernization
+
+Do not apply single-file assumptions here.
+
+## Large solution triage
+
+When a solution contains more than a handful of projects, don't try to model everything at once. Classify projects first, then present a focused list.
+
+### Step 1: Classify all projects
+
+For every `.csproj` in the solution, determine its role:
+
+| Classification | How to detect | Action |
+|---------------|---------------|--------|
+| **Runnable service** | `OutputType` = `Exe` or `WinExe`, not a test project, not the AppHost | Candidate for AppHost modeling |
+| **Class library** | `OutputType` = `Library` | Skip — these are dependencies, not services |
+| **Test project** | References xUnit/NUnit/MSTest, or name ends in `.Test`/`.Tests`/`.IntegrationTest` | Skip |
+| **Migration runner** | Name contains `Migrat`, or references `DbUp`/`FluentMigrator`/EF migrations tooling | Special handling — see below |
+| **Utility/tool** | Located in `util/`, `tools/`, or `scripts/` directories; not a long-running service | Skip unless user requests |
+| **AppHost** | `IsAspireHost` = `true` | Skip — this is the host itself |
+
+Run `dotnet msbuild <project> -getProperty:OutputType` to classify. For large solutions, batch these calls.
+
+### Step 2: Check for multiple source roots
+
+Some repos keep code in more than one top-level directory. Common patterns:
+
+- `src/` + `bitwarden_license/src/` (open-source vs commercial)
+- `src/` + `util/` (services vs utilities)
+- `apps/` + `packages/` (monorepo with shared packages)
+
+Scan all directories in the solution, not just `src/`. If you find projects outside `src/`, note them and ask the user if they should be included.
+
+### Step 3: Present the focused list
+
+Group runnable services by category and present them concisely. For a repo with 60+ projects, show something like:
+
+> *"I found 8 runnable web services (Api, Admin, Identity, Billing, Events, EventsProcessor, Icons, Notifications), 5 class libraries (Core, SharedWeb, Infrastructure.Dapper, Infrastructure.EntityFramework, Sql), 3 migration runners (Migrator, MsSqlMigratorUtility, PostgresMigrations), and 40+ test projects.*
+>
+> *I recommend starting with the core services. Which of the 8 web services should I include in the AppHost?"*
+
+**Do not dump a flat list of 60+ projects.** Classify, summarize, and let the user choose.
+
+### Incremental "core loop" wiring
+
+For solutions with 5 or more runnable services, recommend starting with a **core loop** — the minimum set of services needed for a useful local dev session — and expanding from there.
+
+The core loop is typically:
+
+1. The primary API service
+2. Its database dependency
+3. Any authentication/identity service
+4. The essential cache (Redis, etc.)
+
+Present this explicitly:
+
+> *"You have 8 services. I recommend wiring the core loop first — Api, Identity, and the database — so we can validate `aspire start` works. Then we'll add the remaining services. Sound good?"*
+
+**After the core loop succeeds with `aspire start`:**
+
+1. Stop the AppHost
+2. Add the next batch of services (2-3 at a time) to the AppHost
+3. Run `aspire start` again to validate
+4. If it fails, diagnose and fix before adding more
+5. Repeat until all selected services are wired
+
+Present progress to the user as you go:
+
+> *"Core loop is working (Api + Identity + Postgres + Redis). Adding the next batch: Admin, Billing, and Events..."*
+
+Do not consider the skill complete until all services the user selected in Step 3 are wired and `aspire start` runs with all of them healthy. The core loop is a risk-reduction strategy, not an excuse to stop early.
+
+## Migration runners and setup utilities
+
+Migration runners (database migrations, schema updates, data seeders) deserve special handling. They aren't long-running services — they run once and exit.
+
+Present the user with options:
+
+1. **Model as a project resource with `WaitForCompletion()`** — the migration runs at startup and dependent services wait for it to finish before starting:
+
+```csharp
+var db = builder.AddSqlServer("mssql").AddDatabase("vault");
+var migrator = builder.AddProject<Projects.Migrator>("migrator")
+    .WithReference(db)
+    .WaitFor(db);
+
+var api = builder.AddProject<Projects.Api>("api")
+    .WithReference(db)
+    .WaitForCompletion(migrator);  // api waits for migrations to finish
+```
+
+2. **Leave as manual** — the developer runs migrations separately before `aspire start`. Note this in an AppHost comment:
+
+```csharp
+// Run migrations manually: dotnet run --project ../util/Migrator
+var db = builder.AddSqlServer("mssql").AddDatabase("vault");
+```
+
+Recommend option 1 for repos that currently run migrations as part of their docker-compose or startup scripts. Recommend option 2 for repos where migrations are a deliberate, explicit step.
+
+## Custom MSBuild SDKs
+
+Check `global.json` for `msbuild-sdks` entries beyond the standard Microsoft ones. Common SDKs like `Microsoft.Build.Traversal` are well-known, but custom SDKs (e.g., `Bitwarden.Server.Sdk`) are opaque.
+
+When you find a custom MSBuild SDK:
+
+- **Don't assume project properties are reliable** — the custom SDK may override `OutputType`, inject implicit references, or modify build behavior in ways you can't see
+- **Note it to the user** — *"This repo uses a custom MSBuild SDK (Bitwarden.Server.Sdk). I'll classify projects based on their directory structure and names as well as MSBuild properties, since the custom SDK may affect property evaluation."*
+- **Cross-reference with directory structure** — if `OutputType` says `Library` but the project is in `src/Api/` and has a `Program.cs` and `Startup.cs`, it's likely a runnable service whose OutputType is set by the custom SDK
+
+## Conditional compilation
+
+Some repos use `#if` / `#endif` to maintain multiple build variants from the same source:
+
+```csharp
+#if OSS
+    services.AddOosServices();
+#else
+    services.AddCommercialCoreServices();
+#endif
+```
+
+When you detect conditional compilation in `Program.cs` or `Startup.cs`:
+
+1. **Surface it early** — *"Your services use `#if OSS` conditional compilation, which means the app behaves differently depending on the build configuration. Which variant should the AppHost target — OSS or commercial?"*
+2. **Don't try to model both** — pick the variant the user selects and wire accordingly
+3. **Note the other variant** — leave a comment in the AppHost: `// This AppHost targets the OSS build. For commercial, adjust service registrations.`
+
+This is not a priority to solve perfectly — just make sure the agent doesn't silently pick the wrong variant.
+
+## Mixed SDK repos
+
+Some repos pin the root `global.json` to an older SDK such as .NET 8. A `.csproj`-based Aspire AppHost should still stay on the current Aspire-supported SDK (for example, .NET 10), while existing service projects can remain on `net8.0`.
+
+**Do not downgrade the AppHost project to match the repo's root SDK pin. Do not change the root `global.json`. Do not change any existing project's `<TargetFramework>`.**
+
+### Create a nested `global.json` for the AppHost
+
+If the repo's root `global.json` pins an older SDK and the AppHost is in full project mode, you **must** create a nested `global.json` inside the AppHost directory so it builds with the correct SDK. Check whether one already exists before creating it.
+
+Steps:
+
+1. Keep the repo root `global.json` unchanged.
+2. Check if a `global.json` already exists in the AppHost directory — if so, skip this.
+3. Create a `global.json` next to the AppHost `.csproj` that pins the Aspire-supported SDK:
+
+```json
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}
+```
+
+4. Leave existing services targeting their current TFM unless the user explicitly asks to migrate them.
+
+### Important solution caveat
+
+If the repo's normal root build runs under SDK 8, do **not** assume it can safely own a `net10.0` AppHost project.
+
+When that's likely to break the repo's normal build:
+
+- tell the user explicitly
+- prefer keeping the AppHost isolated in its own folder
+- only add it to the root solution if the user wants that tradeoff
+
+## Solution membership
+
+A discovered solution means the AppHost was created in project mode, but that does **not** always mean every new project should be added to the root solution automatically.
+
+Use this decision order:
+
+1. If the root solution already includes the services being modeled and is the normal local entry point, prefer adding the AppHost and ServiceDefaults there.
+2. If the root solution is tightly coupled to an older SDK/toolchain and adding a `net10.0` AppHost is likely to break routine builds, keep the AppHost outside the solution or in a safer sibling solution boundary.
+3. If you're unsure, ask instead of guessing.
+
+## ServiceDefaults in solution-backed repos
+
+Before creating or wiring ServiceDefaults:
+
+1. Look for an existing ServiceDefaults project or equivalent shared bootstrap code.
+2. Check whether selected services already have tracing, health checks, or service discovery setup.
+3. Check whether the service bootstrap is modern enough for `AddServiceDefaults()` and `MapDefaultEndpoints()`.
+
+If a ServiceDefaults project already exists, reuse it instead of creating another one.
+
+## Legacy bootstrap detection: `IHostBuilder` vs `IHostApplicationBuilder`
+
+This is the easy-to-forget gotcha.
+
+The generated ServiceDefaults extensions typically target **`IHostApplicationBuilder`** and **`WebApplication`** patterns:
+
+```csharp
+builder.AddServiceDefaults();
+app.MapDefaultEndpoints();
+```
+
+That drops cleanly into modern code such as:
+
+- `var builder = WebApplication.CreateBuilder(args);`
+- `var builder = Host.CreateApplicationBuilder(args);`
+
+It does **not** automatically map onto older patterns such as:
+
+- `Host.CreateDefaultBuilder(args)`
+- `ConfigureWebHostDefaults(...)`
+- `UseStartup<Startup>()`
+- `IHostBuilder`-only worker/bootstrap code
+
+### What to do when you find legacy hosting
+
+Do **not** silently jam ServiceDefaults into the old shape. **Do not create adapter extension methods on `IHostBuilder`** — ServiceDefaults is designed for `IHostApplicationBuilder` and should only be used with the modern bootstrap pattern.
+
+There are exactly two options. Present them clearly:
+
+1. **Skip ServiceDefaults for now** (recommended for initial setup)
+   - Model the service in the AppHost with `AddProject<T>()` or `AddCSharpApp()`
+   - The service appears in the dashboard, gets environment wiring, and shows logs
+   - No code changes to the service project needed
+   - Health checks, service discovery, and OTel from ServiceDefaults are deferred
+
+2. **Modernize the service's bootstrap** (larger change, per-service)
+   - Convert `Program.cs` from `Host.CreateDefaultBuilder()` to `WebApplication.CreateBuilder()`
+   - Inline the `Startup.ConfigureServices()` into `builder.Services.*` calls
+   - Inline the `Startup.Configure()` into the `app.*` middleware pipeline
+   - Then add `builder.AddServiceDefaults()` and `app.MapDefaultEndpoints()`
+   - Existing `IHostBuilder` extensions (like custom logging, SDK setup) can be called via `builder.Host.*`
+
+**When multiple services share the same legacy pattern, batch the decision.** If 8 services all use `Host.CreateDefaultBuilder` + `UseStartup<T>`, don't ask 8 times. Ask once:
+
+> *"All 8 of your web services use the legacy IHostBuilder + Startup pattern. I can either (a) model them all in the AppHost without ServiceDefaults for now — they'll appear in the dashboard and get environment wiring but won't have health checks or service discovery — or (b) modernize each service's bootstrap to the WebApplicationBuilder pattern so ServiceDefaults works fully. Which approach do you prefer? You can also mix — modernize a few key services and leave the rest."*
+
+If the repo is conservative or large, default to **asking**, not migrating automatically.
+
+## Modernization guidance
+
+### ASP.NET Core app using `IHostBuilder` / `Startup`
+
+If the user wants full ServiceDefaults support, migrate toward a `WebApplicationBuilder` shape.
+
+Target pattern:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddServiceDefaults();
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.MapControllers();
+app.MapDefaultEndpoints();
+
+app.Run();
+```
+
+Preserve existing service registrations and middleware ordering carefully. Move only what is required to land on a `WebApplicationBuilder`/`WebApplication` pipeline.
+
+When the `Startup` class has custom extension methods (e.g., `UseBitwardenSdk()`, `AddGlobalSettingsServices()`), those typically need to be called on the new `builder` or `app` in the appropriate phase. Don't silently drop them — trace each call to its registration phase (services vs middleware) and preserve it.
+
+### Worker/background service using `IHostBuilder`
+
+If the service is a worker and the user wants ServiceDefaults, migrate toward `Host.CreateApplicationBuilder(args)`:
+
+```csharp
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.AddServiceDefaults();
+builder.Services.AddHostedService<Worker>();
+
+var host = builder.Build();
+await host.RunAsync();
+```
+
+For non-web workers, `MapDefaultEndpoints()` usually does not apply unless the app exposes HTTP endpoints.
+
+## AppHost project references
+
+For full project mode, prefer explicit project references from the AppHost to selected .NET services:
+
+```bash
+dotnet add <AppHost.csproj> reference <Api.csproj>
+```
+
+This keeps solution-backed AppHosts easier to navigate and build.
+
+## Validation checklist for full-solution mode
+
+Before declaring success:
+
+1. The AppHost project builds under its intended SDK boundary.
+2. The root solution still behaves the way the user expects, or the user has explicitly accepted any tradeoff.
+3. Any ServiceDefaults changes compile in the selected services.
+4. `aspire start` works from the AppHost context, and long-lived app resources are healthy rather than merely `Finished`.
+5. Legacy `IHostBuilder` services were either modernized intentionally or explicitly left unchanged.
+6. Migration runners, if modeled, complete successfully before dependent services start.
+
+## When to ask the user instead of deciding
+
+Ask when:
+
+- adding the AppHost to the root solution might break the repo's normal SDK/build
+- a service uses `Startup.cs` / `IHostBuilder` and would need real bootstrap surgery
+- there are multiple plausible ServiceDefaults/shared-bootstrap projects to reuse
+- the repo has mixed solution boundaries and it's unclear which one is the real developer entry point
+- the repo has a custom MSBuild SDK and project classification is ambiguous
+- the repo uses conditional compilation and the target variant is unclear
+- there are more than 5 runnable services and you need to decide which to wire first

--- a/.agents/skills/aspireify/references/javascript-apps.md
+++ b/.agents/skills/aspireify/references/javascript-apps.md
@@ -1,0 +1,150 @@
+# JavaScript and TypeScript app patterns
+
+Use this reference when wiring JavaScript/TypeScript services into the AppHost or configuring TypeScript AppHost dependencies (Step 5 and Step 6).
+
+## Choosing the right JavaScript resource type
+
+The `Aspire.Hosting.JavaScript` package provides three resource types. Pick the right one:
+
+| Signal | Use | Example |
+|--------|-----|---------|
+| Vite app (has `vite.config.*`) | `AddViteApp(name, dir)` | Frontend SPA, Vite + React/Vue/Svelte |
+| App runs via package.json script only | `AddJavaScriptApp(name, dir, { runScriptName })` | CRA app, Next.js, monorepo root scripts |
+| App has a specific Node entry file (`.js`/`.ts`) and uses a dev script like `ts-node-dev` | `AddNodeApp(name, dir, "entry.js")` + `.WithRunScript("start:dev")` | Express/Fastify API, Socket.IO server |
+
+**Key distinctions:**
+- `AddNodeApp` is for apps that run a **specific file** with Node (e.g., an Express server at `src/index.ts`). Use `.WithRunScript("start:dev")` to override the dev-time command (e.g., `ts-node-dev`).
+- `AddJavaScriptApp` runs a **package.json script** — simpler, good when the script handles everything.
+- `AddViteApp` is `AddJavaScriptApp` with Vite-specific defaults (auto-HTTPS config augmentation, `dev` as default script).
+
+## JavaScript dev scripts
+
+Use `.WithRunScript()` to control which package.json script runs during development:
+
+```typescript
+// Express API with TypeScript: uses ts-node-dev for hot reload in dev
+const api = await builder
+    .addNodeApp("api", "./api", "src/index.ts")
+    .withRunScript("start:dev")                      // runs "yarn start:dev" (ts-node-dev)
+    .withYarn()
+    .withHttpEndpoint({ env: "PORT" });
+
+// Vite frontend: default "dev" script is fine, just add yarn
+const web = await builder
+    .addViteApp("web", "./frontend")
+    .withYarn();
+```
+
+## Framework-specific port binding
+
+Not all frameworks read ports from env vars the same way:
+
+| Framework | Port mechanism | AppHost pattern |
+|-----------|---------------|-----------------|
+| Express/Fastify | `process.env.PORT` | `.withHttpEndpoint({ env: "PORT" })` |
+| Vite | `--port` CLI arg or `server.port` in config | `.withHttpEndpoint({ env: "PORT" })` — Aspire's Vite integration handles this automatically |
+| Next.js | `PORT` env or `--port` | `.withHttpEndpoint({ env: "PORT" })` |
+| CRA | `PORT` env | `.withHttpEndpoint({ env: "PORT" })` |
+
+When the framework supports reading the port from an env var or Aspire already handles it, **prefer that over pinning a fixed port**. Managed ports make repeated local runs more reliable and work better when multiple services or multiple Aspire apps are running.
+
+**Suppress auto-browser-open:** Many dev servers (Vite, CRA, Next.js) auto-open a browser on start. Add `.withEnvironment("BROWSER", "none")` to prevent this in Aspire-managed apps. Vite also respects `server.open: false` in its config.
+
+## Yarn/pnpm workspace monorepos
+
+In monorepos that use **yarn workspaces** or **pnpm workspaces**, all workspace packages share a single root-level `node_modules/` directory (hoisted or symlinked). This creates two specific problems with `.withYarn()` / `.withPnpm()`:
+
+1. **Concurrent install conflicts (Windows)**: `.withYarn()` runs `yarn install` before each resource starts. When multiple resources start concurrently, each triggers a root-level `yarn install` that tries to write to the shared `node_modules/`. On Windows, this causes `EPERM: operation not permitted` errors when one resource's running process (e.g., `esbuild.exe`) holds a file lock while another `yarn install` tries to overwrite it.
+
+2. **Redundant installs**: In a properly set up workspace, `yarn` at the root installs everything for all workspaces. Running `yarn install` per-resource is redundant and slow.
+
+**The fix: don't use `.withYarn()` on individual workspace resources.** Instead, ensure dependencies are installed once at the root before starting:
+
+```typescript
+// ❌ WRONG for workspace monorepos — concurrent installs cause file locking errors
+const app = await builder.addViteApp("app", "./packages/frontend")
+    .withYarn();  // triggers yarn install at startup → EPERM on Windows
+
+const api = await builder.addNodeApp("api", "./packages/api", "src/index.ts")
+    .withYarn();  // second concurrent yarn install → file lock conflict
+
+// ✅ CORRECT for workspace monorepos — deps already installed at root
+const app = await builder.addViteApp("app", "./packages/frontend");
+
+const api = await builder.addNodeApp("api", "./packages/api", "src/index.ts")
+    .withRunScript("start:dev");
+```
+
+Tell the user: *"This is a yarn workspace monorepo — I'll skip `.withYarn()` on individual resources since dependencies are shared at the root. Make sure to run `yarn` at the root before `aspire start`."*
+
+**This only applies to workspace monorepos with shared `node_modules`.** For standalone apps or apps with independent `node_modules` directories, `.withYarn()` / `.withPnpm()` is correct and should be used — it ensures deps are installed before the resource starts.
+
+## TypeScript AppHost dependency configuration (Step 6)
+
+### package.json
+
+If one exists at the root, augment it (do not overwrite). Add/merge these scripts that delegate to the Aspire CLI:
+
+```json
+{
+  "type": "module",
+  "scripts": {
+    "dev": "aspire run",
+    "build": "tsc",
+    "watch": "tsc --watch"
+  }
+}
+```
+
+If no root `package.json` exists, create a minimal one matching the canonical Aspire template:
+
+```json
+{
+  "name": "<repo-name>",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "aspire run",
+    "build": "tsc",
+    "watch": "tsc --watch"
+  },
+  "engines": {
+    "node": "^20.19.0 || ^22.13.0 || >=24"
+  }
+}
+```
+
+**Important**: Scripts should point to `aspire run`/`aspire start` — the Aspire CLI handles TypeScript compilation internally. Do not use `npx tsc && node apphost.js` patterns.
+
+Never overwrite existing `scripts`, `dependencies`, or `devDependencies` — merge only. Do not manually add Aspire SDK packages — `aspire restore` handles those.
+
+Run `aspire restore` to generate the `.modules/` directory with TypeScript SDK bindings, then install dependencies with the repo's package manager (`npm install`, `pnpm install`, or `yarn`).
+
+### tsconfig.json
+
+Augment if it exists:
+
+- Ensure `".modules/**/*.ts"` and `"apphost.ts"` are in `include`
+- Ensure `"module"` is `"nodenext"` or `"node16"` (ESM required)
+- Ensure `"moduleResolution"` matches
+
+If no `tsconfig.json` exists and `aspire restore` didn't create one, create a minimal one:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "esModuleInterop": true,
+    "strict": true,
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": ["apphost.ts", ".modules/**/*.ts"]
+}
+```
+
+### ESLint
+
+Only augment if config already exists. If it uses `parserOptions.project` or `parserOptions.projectService`, ensure the AppHost tsconfig is discoverable. Do not create ESLint configuration from scratch.

--- a/.agents/skills/aspireify/references/opentelemetry.md
+++ b/.agents/skills/aspireify/references/opentelemetry.md
@@ -1,0 +1,112 @@
+# OpenTelemetry setup for non-.NET services
+
+Use this reference when the user opts in to adding OpenTelemetry instrumentation to non-.NET services (Step 8). Aspire automatically injects `OTEL_EXPORTER_OTLP_ENDPOINT` into all managed resources — the services just need to read it.
+
+## Node.js/TypeScript services
+
+```bash
+# Use the repo's package manager (npm/pnpm/yarn)
+npm install @opentelemetry/sdk-node @opentelemetry/auto-instrumentations-node @opentelemetry/exporter-otlp-grpc
+# or: pnpm add ...
+# or: yarn add ...
+```
+
+Create an instrumentation file (e.g., `instrumentation.ts` or `instrumentation.js`):
+
+```typescript
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-otlp-grpc';
+import { OTLPMetricExporter } from '@opentelemetry/exporter-otlp-grpc';
+import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+
+const sdk = new NodeSDK({
+  traceExporter: new OTLPTraceExporter(),
+  metricReader: new PeriodicExportingMetricReader({
+    exporter: new OTLPMetricExporter(),
+  }),
+  instrumentations: [getNodeAutoInstrumentations()],
+  serviceName: process.env.OTEL_SERVICE_NAME,
+});
+
+sdk.start();
+```
+
+Then ensure the service loads it early — either via `--require`/`--import` in the start script or by importing it as the first line of the entry point.
+
+## Python services
+
+```bash
+pip install opentelemetry-distro opentelemetry-exporter-otlp
+opentelemetry-bootstrap -a install  # auto-detect and install framework instrumentations
+```
+
+Add to the service's startup (e.g., top of `main.py` or as a separate `instrumentation.py`):
+
+```python
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry import trace, metrics
+import os
+
+resource = Resource.create({"service.name": os.environ.get("OTEL_SERVICE_NAME", "unknown")})
+
+# Traces
+trace.set_tracer_provider(TracerProvider(resource=resource))
+trace.get_tracer_provider().add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+
+# Metrics
+metrics.set_meter_provider(MeterProvider(
+    resource=resource,
+    metric_readers=[PeriodicExportingMetricReader(OTLPMetricExporter())],
+))
+```
+
+Or more simply, run with the auto-instrumentation wrapper:
+
+```bash
+opentelemetry-instrument uvicorn main:app --host 0.0.0.0
+```
+
+## Go services
+
+```bash
+go get go.opentelemetry.io/otel
+go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc
+go get go.opentelemetry.io/otel/sdk/trace
+go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
+```
+
+Add initialization in `main()`:
+
+```go
+import (
+    "go.opentelemetry.io/otel"
+    "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+    sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+func initTracer() func() {
+    exporter, _ := otlptracegrpc.New(context.Background())
+    tp := sdktrace.NewTracerProvider(sdktrace.WithBatcher(exporter))
+    otel.SetTracerProvider(tp)
+    return func() { tp.Shutdown(context.Background()) }
+}
+```
+
+Wrap HTTP handlers with `otelhttp.NewHandler()` for automatic HTTP span creation.
+
+## Java services
+
+Point the user to the [OpenTelemetry Java Agent](https://opentelemetry.io/docs/zero-code/java/agent/) — it's the easiest approach:
+
+```bash
+java -javaagent:opentelemetry-javaagent.jar -jar myapp.jar
+```
+
+The agent auto-instruments common frameworks. Aspire injects `OTEL_EXPORTER_OTLP_ENDPOINT` automatically.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,19 @@ builder.AddDockerComposeEnvironment("env")
     .WithSshDeploySupport();
 ```
 
-3. Deploy:
+TypeScript AppHosts can reference the package from `aspire.config.json`, run `aspire restore`,
+and use the generated API:
+
+```typescript
+import { createBuilder } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+
+await builder.addDockerComposeEnvironment('env')
+    .withSshDeploySupport();
+```
+
+4. Deploy:
 
 ```bash
 aspire deploy
@@ -89,14 +101,26 @@ See the [package README](src/Aspire.Hosting.Docker.SshDeploy/README.md) for:
 - Configuration options (`appsettings.json`, environment variables)
 - SSH authentication (key-based vs password)
 - Target host privacy settings
+- TypeScript AppHost setup
 
-## Sample Project
+## Sample Projects
 
-See `samples/DockerPipelinesSample` for a complete example:
+See `samples/DockerPipelinesSample` for a complete C# AppHost example:
 
 ```bash
 aspire run     # Run locally
 aspire deploy  # Deploy to remote host
+```
+
+See `samples/DockerPipelinesTypeScriptSample` for a TypeScript AppHost sample that uses the generated
+`Aspire.Hosting.Docker.SshDeploy` APIs against the same API and web projects:
+
+```bash
+cd samples/DockerPipelinesTypeScriptSample
+npm install
+aspire restore
+npm run build
+aspire deploy
 ```
 
 ## CI/CD with GitHub Actions

--- a/samples/DockerPipelinesTypeScriptSample/.gitignore
+++ b/samples/DockerPipelinesTypeScriptSample/.gitignore
@@ -1,0 +1,3 @@
+.modules/
+dist/
+node_modules/

--- a/samples/DockerPipelinesTypeScriptSample/README.md
+++ b/samples/DockerPipelinesTypeScriptSample/README.md
@@ -1,0 +1,12 @@
+# Docker Pipelines TypeScript Sample
+
+This sample uses a TypeScript Aspire AppHost to deploy the existing sample API and web projects with `Aspire.Hosting.Docker.SshDeploy`.
+
+```bash
+npm install
+aspire restore
+npm run build
+aspire deploy
+```
+
+The AppHost references the local `Aspire.Hosting.Docker.SshDeploy.csproj`, so changes to the hosting integration are reflected after `aspire restore`.

--- a/samples/DockerPipelinesTypeScriptSample/apphost.ts
+++ b/samples/DockerPipelinesTypeScriptSample/apphost.ts
@@ -1,0 +1,31 @@
+// Sample: SSH deployment from a TypeScript AppHost.
+// Demonstrates: generated TypeScript APIs for Aspire.Hosting.Docker.SshDeploy.
+
+import { createBuilder, PullPolicy } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+
+await builder.addDockerComposeEnvironment('env')
+    .withSshDeploySupport()
+    .withImagePullPolicy(PullPolicy.Missing)
+    .withAppFileTransfer('./config', 'config');
+
+const cache = await builder.addRedis('cache');
+
+const apiService = await builder.addProject(
+    'apiservice',
+    '../DockerPipelinesSample/DockerPipelinesSample.ApiService/DockerPipelinesSample.ApiService.csproj')
+    .withHttpHealthCheck({ path: '/health' });
+
+await builder.addProject(
+    'webfrontend',
+    '../DockerPipelinesSample/DockerPipelinesSample.Web/DockerPipelinesSample.Web.csproj')
+    .withHttpHealthCheck({ path: '/health' })
+    .withReference(cache)
+    .waitFor(cache)
+    .withReference(apiService)
+    .waitFor(apiService)
+    .withEnvironment('IMAGE_TAG_SUFFIX', process.env.IMAGE_TAG_SUFFIX ?? 'local')
+    .withExternalHttpEndpoints();
+
+await builder.build().run();

--- a/samples/DockerPipelinesTypeScriptSample/aspire.config.json
+++ b/samples/DockerPipelinesTypeScriptSample/aspire.config.json
@@ -1,0 +1,13 @@
+{
+  "appHost": {
+    "path": "apphost.ts",
+    "language": "typescript/nodejs"
+  },
+  "sdk": {
+    "version": "13.3.0"
+  },
+  "packages": {
+    "Aspire.Hosting.Docker.SshDeploy": "../../src/Aspire.Hosting.Docker.SshDeploy/Aspire.Hosting.Docker.SshDeploy.csproj",
+    "Aspire.Hosting.Redis": "13.2.4"
+  }
+}

--- a/samples/DockerPipelinesTypeScriptSample/config/sample.txt
+++ b/samples/DockerPipelinesTypeScriptSample/config/sample.txt
@@ -1,0 +1,1 @@
+This file is copied to the remote deployment directory by withAppFileTransfer().

--- a/samples/DockerPipelinesTypeScriptSample/eslint.config.mjs
+++ b/samples/DockerPipelinesTypeScriptSample/eslint.config.mjs
@@ -1,0 +1,18 @@
+// @ts-check
+
+import { defineConfig } from 'eslint/config';
+import tseslint from 'typescript-eslint';
+
+export default defineConfig({
+  files: ['apphost.ts'],
+  extends: [tseslint.configs.base],
+  languageOptions: {
+    parserOptions: {
+      project: './tsconfig.apphost.json',
+      tsconfigRootDir: import.meta.dirname,
+    },
+  },
+  rules: {
+    '@typescript-eslint/no-floating-promises': ['error', { checkThenables: true }],
+  },
+});

--- a/samples/DockerPipelinesTypeScriptSample/package-lock.json
+++ b/samples/DockerPipelinesTypeScriptSample/package-lock.json
@@ -1,0 +1,2063 @@
+{
+  "name": "docker-pipelines-typescript-sample",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "docker-pipelines-typescript-sample",
+      "version": "1.0.0",
+      "dependencies": {
+        "vscode-jsonrpc": "^8.2.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "eslint": "^10.0.3",
+        "nodemon": "^3.1.14",
+        "tsx": "^4.21.0",
+        "typescript": "^5.9.3",
+        "typescript-eslint": "^8.57.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
+      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/type-utils": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.59.2",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
+      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
+      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.2",
+        "@typescript-eslint/types": "^8.59.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
+      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
+      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
+      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
+      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
+      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.2",
+        "@typescript-eslint/tsconfig-utils": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
+      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
+      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.2",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
+      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nodemon": {
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
+      "integrity": "sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^10.2.1",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
+      "integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.59.2",
+        "@typescript-eslint/parser": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/samples/DockerPipelinesTypeScriptSample/package.json
+++ b/samples/DockerPipelinesTypeScriptSample/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "docker-pipelines-typescript-sample",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": "^20.19.0 || ^22.13.0 || >=24"
+  },
+  "scripts": {
+    "aspire:lint": "eslint apphost.ts",
+    "aspire:start": "aspire run",
+    "aspire:build": "tsc -p tsconfig.apphost.json",
+    "aspire:dev": "tsc --watch -p tsconfig.apphost.json",
+    "lint": "npm run aspire:lint",
+    "predev": "npm run aspire:lint",
+    "dev": "npm run aspire:start",
+    "prebuild": "npm run aspire:lint",
+    "build": "npm run aspire:build",
+    "watch": "npm run aspire:dev"
+  },
+  "dependencies": {
+    "vscode-jsonrpc": "^8.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "eslint": "^10.0.3",
+    "nodemon": "^3.1.14",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.57.1"
+  }
+}

--- a/samples/DockerPipelinesTypeScriptSample/tsconfig.apphost.json
+++ b/samples/DockerPipelinesTypeScriptSample/tsconfig.apphost.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "./dist/apphost",
+    "rootDir": "."
+  },
+  "include": ["apphost.ts", ".modules/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/src/Aspire.Hosting.Docker.SshDeploy/Aspire.Hosting.Docker.SshDeploy.csproj
+++ b/src/Aspire.Hosting.Docker.SshDeploy/Aspire.Hosting.Docker.SshDeploy.csproj
@@ -16,6 +16,7 @@
     <RepositoryUrl>https://github.com/davidfowl/AspirePipelines</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <NoWarn>$(NoWarn);ASPIREATS001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Docker.SshDeploy/DockerPipelineExtensions.cs
+++ b/src/Aspire.Hosting.Docker.SshDeploy/DockerPipelineExtensions.cs
@@ -82,6 +82,7 @@ public static class DockerPipelineExtensions
     /// 
     /// This deployment pipeline is only active when publishing the application and has no effect during local development.
     /// </remarks>
+    [AspireExport("withSshDeploySupport", Description = "Adds SSH deployment support to a Docker Compose environment resource.")]
     public static IResourceBuilder<DockerComposeEnvironmentResource> WithSshDeploySupport(
         this IResourceBuilder<DockerComposeEnvironmentResource> resourceBuilder)
     {
@@ -205,6 +206,7 @@ public static class DockerPipelineExtensions
     /// <param name="localPath">The local path (relative to AppHost directory) containing files to transfer.</param>
     /// <param name="remoteSubPath">The subdirectory within RemoteDeployPath where files will be transferred.</param>
     /// <returns>The resource builder for method chaining.</returns>
+    [AspireExport("withAppFileTransfer", Description = "Transfers files to a path relative to the remote deployment directory.")]
     public static IResourceBuilder<DockerComposeEnvironmentResource> WithAppFileTransfer(
         this IResourceBuilder<DockerComposeEnvironmentResource> builder,
         string localPath,
@@ -222,6 +224,7 @@ public static class DockerPipelineExtensions
     /// <param name="localPath">The local path (relative to AppHost directory) containing files to transfer.</param>
     /// <param name="remotePath">A parameter resource that resolves to the absolute remote destination directory.</param>
     /// <returns>The resource builder for method chaining.</returns>
+    [AspireExportIgnore(Reason = "The string overload is exported for TypeScript AppHosts. Parameter-backed remote paths are a C# convenience overload.")]
     public static IResourceBuilder<DockerComposeEnvironmentResource> WithFileTransfer(
         this IResourceBuilder<DockerComposeEnvironmentResource> builder,
         string localPath,
@@ -239,6 +242,7 @@ public static class DockerPipelineExtensions
     /// <param name="localPath">The local path (relative to AppHost directory) containing files to transfer.</param>
     /// <param name="remotePath">The absolute remote destination directory path (supports $HOME and ~ expansion).</param>
     /// <returns>The resource builder for method chaining.</returns>
+    [AspireExport("withFileTransfer", Description = "Transfers files to an absolute path on the remote deployment target.")]
     public static IResourceBuilder<DockerComposeEnvironmentResource> WithFileTransfer(
         this IResourceBuilder<DockerComposeEnvironmentResource> builder,
         string localPath,
@@ -248,6 +252,7 @@ public static class DockerPipelineExtensions
         return builder;
     }
 
+    /// <summary>
     /// Sets the image pull policy used when the deploy pipeline runs <c>docker compose up</c> on
     /// the remote. Wins over the <c>Deployment:PullPolicy</c> configuration string when both are
     /// set. Method name matches the <c>WithImagePullPolicy</c> convention used elsewhere in Aspire.
@@ -262,6 +267,7 @@ public static class DockerPipelineExtensions
     /// Takes <see cref="PullPolicy"/> rather than <c>Aspire.Hosting.ApplicationModel.ImagePullPolicy</c>
     /// because the latter does not include <c>Never</c> until Aspire 13.2.
     /// </remarks>
+    [AspireExport("withImagePullPolicy", Description = "Sets the image pull policy used for remote docker compose deployments.")]
     public static IResourceBuilder<DockerComposeEnvironmentResource> WithImagePullPolicy(
         this IResourceBuilder<DockerComposeEnvironmentResource> builder,
         PullPolicy policy)
@@ -291,6 +297,7 @@ public static class DockerPipelineExtensions
     /// Aspire always emits as <c>{registry-endpoint}/{repo}/{name}:{tag}</c>). Values without a
     /// slash and non-image variables are left untouched.
     /// </remarks>
+    [AspireExport("withPullRegistry", Description = "Rewrites generated image references so the remote Docker daemon pulls from a different registry endpoint.")]
     public static IResourceBuilder<DockerComposeEnvironmentResource> WithPullRegistry(
         this IResourceBuilder<DockerComposeEnvironmentResource> builder,
         string endpoint)

--- a/src/Aspire.Hosting.Docker.SshDeploy/README.md
+++ b/src/Aspire.Hosting.Docker.SshDeploy/README.md
@@ -19,6 +19,53 @@ aspire add docker-sshdeploy
 dotnet add package Aspire.Hosting.Docker.SshDeploy --prerelease
 ```
 
+## TypeScript AppHosts
+
+TypeScript AppHosts can use the same Docker SSH deployment APIs. Add the package to
+`aspire.config.json` and regenerate `.modules` with `aspire restore` or `aspire add`:
+
+```json
+{
+  "appHost": {
+    "path": "apphost.ts",
+    "language": "typescript/nodejs"
+  },
+  "packages": {
+    "Aspire.Hosting.Docker.SshDeploy": "<package-version>"
+  }
+}
+```
+
+For local development against this repository, reference the project file instead:
+
+```json
+{
+  "packages": {
+    "Aspire.Hosting.Docker.SshDeploy": "../src/Aspire.Hosting.Docker.SshDeploy/Aspire.Hosting.Docker.SshDeploy.csproj"
+  }
+}
+```
+
+Then use the generated API from `.modules/aspire.js`:
+
+```typescript
+import { createBuilder, PullPolicy } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+
+await builder.addDockerComposeEnvironment('env')
+    .withSshDeploySupport()
+    .withImagePullPolicy(PullPolicy.Never)
+    .withPullRegistry('localhost:5001')
+    .withAppFileTransfer('./certs', 'certs')
+    .withFileTransfer('./config', '$HOME/config');
+
+await builder.build().run();
+```
+
+See `samples/DockerPipelinesTypeScriptSample` in this repository for a complete TypeScript AppHost
+sample that deploys the existing API and web projects.
+
 ## Usage Scenarios
 
 ### 1. Interactive Mode (Simplest)


### PR DESCRIPTION
## Summary
- export Docker SSH deploy APIs for Aspire TypeScript AppHosts
- add a TypeScript AppHost sample that reuses the existing sample API/Web projects
- document TypeScript setup in the root and package READMEs
- include Aspire agent skill files generated by aspire agent init

## Validation
- dotnet build AspirePipelines.slnx
- dotnet test tests\Aspire.Hosting.Docker.SshDeploy.Tests\Aspire.Hosting.Docker.SshDeploy.Tests.csproj
- aspire restore --non-interactive in samples\DockerPipelinesTypeScriptSample
- npm run build in samples\DockerPipelinesTypeScriptSample