### PR TITLE
Upgrade to Aspire 13.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+*.local.json
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/samples/DockerPipelinesSample/DockerPipelinesSample.AppHost/DockerPipelinesSample.AppHost.csproj
+++ b/samples/DockerPipelinesSample/DockerPipelinesSample.AppHost/DockerPipelinesSample.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.2.4">
+<Project Sdk="Aspire.AppHost.Sdk/13.3.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Docker" Version="13.2.4" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="13.2.4" />
-    <PackageReference Include="Aspire.Hosting.Yarp" Version="13.2.4" />
+    <PackageReference Include="Aspire.Hosting.Docker" Version="13.3.0" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.3.0" />
+    <PackageReference Include="Aspire.Hosting.Yarp" Version="13.3.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/DockerPipelinesSample/DockerPipelinesSample.Web/DockerPipelinesSample.Web.csproj
+++ b/samples/DockerPipelinesSample/DockerPipelinesSample.Web/DockerPipelinesSample.Web.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.StackExchange.Redis.OutputCaching" Version="13.2.4" />
+    <PackageReference Include="Aspire.StackExchange.Redis.OutputCaching" Version="13.3.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/DockerPipelinesTypeScriptSample/aspire.config.json
+++ b/samples/DockerPipelinesTypeScriptSample/aspire.config.json
@@ -8,6 +8,6 @@
   },
   "packages": {
     "Aspire.Hosting.Docker.SshDeploy": "../../src/Aspire.Hosting.Docker.SshDeploy/Aspire.Hosting.Docker.SshDeploy.csproj",
-    "Aspire.Hosting.Redis": "13.2.4"
+    "Aspire.Hosting.Redis": "13.3.0"
   }
 }

--- a/src/Aspire.Hosting.Docker.SshDeploy/Aspire.Hosting.Docker.SshDeploy.csproj
+++ b/src/Aspire.Hosting.Docker.SshDeploy/Aspire.Hosting.Docker.SshDeploy.csproj
@@ -24,8 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting" Version="13.2.4" />
-    <PackageReference Include="Aspire.Hosting.Docker" Version="13.2.4" />
+    <PackageReference Include="Aspire.Hosting" Version="13.3.0" />
+    <PackageReference Include="Aspire.Hosting.Docker" Version="13.3.0" />
     <PackageReference Include="SSH.NET" Version="2025.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Bumps `Aspire.Hosting`, `Aspire.Hosting.Docker`, `Aspire.Hosting.Redis`, `Aspire.Hosting.Yarp`, `Aspire.StackExchange.Redis.OutputCaching`, and the AppHost SDK from `13.2.4` to `13.3.0`.
- Updates `samples/DockerPipelinesTypeScriptSample/aspire.config.json` to pin `Aspire.Hosting.Redis` at `13.3.0`.
- Adds `*.local.json` to `.gitignore`.

## Test plan
- [ ] `dotnet build` succeeds
- [ ] `dotnet test` passes
- [ ] DockerPipelinesSample AppHost runs under `aspire run`
- [ ] DockerPipelinesTypeScriptSample AppHost runs under `aspire run`